### PR TITLE
add iqama controller based on config

### DIFF
--- a/lib/AnnouncementTest.dart
+++ b/lib/AnnouncementTest.dart
@@ -60,9 +60,11 @@ class _AnnouncementTestState extends State<AnnouncementTest> {
 
                   children: [
                     announcementWidgets(),
-                   Padding(
-                     padding:  EdgeInsets.only(bottom:1.5.vh ),
-                     child: SalahTimesBar(miniStyle: true),
+                   IgnorePointer(
+                     child: Padding(
+                       padding:  EdgeInsets.only(bottom:1.5.vh ),
+                       child: SalahTimesBar(miniStyle: true),
+                     ),
                    )
                   ],
                 ):Center(

--- a/lib/src/enum/home_active_screen.dart
+++ b/lib/src/enum/home_active_screen.dart
@@ -7,6 +7,7 @@ enum HomeActiveScreen {
   randomHadith,
   jumuaaHadith,
   jumuaaLiveScreen,
+  salahDurationBlackScreen,
   afterSalahAzkar,
   announcementScreen,
 

--- a/lib/src/pages/home/OfflineHomeScreen.dart
+++ b/lib/src/pages/home/OfflineHomeScreen.dart
@@ -80,6 +80,8 @@ class OfflineHomeScreen extends StatelessWidget {
         return JumuaHadithSubScreen();
       case HomeActiveScreen.announcementScreen:
         return AnnouncementScreen();
+      case HomeActiveScreen.salahDurationBlackScreen:
+        return Scaffold(backgroundColor: Colors.black,);
       case HomeActiveScreen.jumuaaLiveScreen:
         return JummuaLive();
         break;

--- a/lib/src/pages/home/sub_screens/AnnouncementScreen.dart
+++ b/lib/src/pages/home/sub_screens/AnnouncementScreen.dart
@@ -24,26 +24,29 @@ class _AnnouncementScreenState extends State<AnnouncementScreen> {
 
   @override
   void initState() {
+    Future.delayed(homeDuration).then((value) {
+      nextScreen();
+    });
     super.initState();
-     if (context.read<MosqueManager>().mosque!.announcements.isNotEmpty) {
-       Future.delayed(homeDuration).then((value) {
-         nextScreen();
-       });
-     }
+
   }
 
 
   @override
   Widget build(BuildContext context) {
-    if (showHome) {
+
+    if (showHome ||context.read<MosqueManager>().mosque!.announcements.length<=activeIndex) {
       return NormalHomeSubScreen();
     }
     return Stack(
+      alignment:Alignment.bottomCenter,
       children: [
         announcementWidgets(),
-        Padding(
-          padding:  EdgeInsets.only(bottom:1.5.vh ),
-          child: SalahTimesBar(miniStyle: true),
+        IgnorePointer(
+          child: Padding(
+            padding:  EdgeInsets.only(bottom:1.5.vh ),
+            child: SalahTimesBar(miniStyle: true),
+          ),
         )
       ],
     );

--- a/lib/src/pages/home/sub_screens/IqamaSubScreen.dart
+++ b/lib/src/pages/home/sub_screens/IqamaSubScreen.dart
@@ -1,9 +1,25 @@
 import 'package:flutter/material.dart';
 import 'package:mawaqit/const/resource.dart';
 import 'package:mawaqit/generated/l10n.dart';
+import 'package:mawaqit/src/services/audio_manager.dart';
+import 'package:mawaqit/src/services/mosque_manager.dart';
+import 'package:provider/provider.dart';
 
-class IqamaSubScreen extends StatelessWidget {
+class IqamaSubScreen extends StatefulWidget {
   const IqamaSubScreen({Key? key}) : super(key: key);
+
+  @override
+  State<IqamaSubScreen> createState() => _IqamaSubScreenState();
+}
+
+class _IqamaSubScreenState extends State<IqamaSubScreen> {
+  @override
+  void initState() {
+    context.read<AudioManager>().loadAndPlayIqamaBipVoice(
+          context.read<MosqueManager>().mosqueConfig,
+        );
+    super.initState();
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/pages/home/sub_screens/JumuaHadithSubScreen.dart
+++ b/lib/src/pages/home/sub_screens/JumuaHadithSubScreen.dart
@@ -67,7 +67,7 @@ class JumuaHadithSubScreen extends StatelessWidget {
         ],
       );
     }
-      return SizedBox();
+      return Scaffold(backgroundColor: Colors.black,);
 
   }
 }

--- a/lib/src/pages/home/sub_screens/normal_home.dart
+++ b/lib/src/pages/home/sub_screens/normal_home.dart
@@ -27,38 +27,46 @@ class NormalHomeSubScreen extends StatelessWidget {
           children: [
             Expanded(
               child: mosqueProvider.showImsak
-                  ? SalahItemWidget(
-                      title: S.of(context).imsak,
-                      time: mosqueProvider.imsak,
-                      removeBackground: true,
-                      withDivider: false,
-                    )
+                  ? Center(
+                    child: SalahItemWidget(
+                        title: S.of(context).imsak,
+                        time: mosqueProvider.imsak,
+                        removeBackground: true,
+                        withDivider: false,
+                      ),
+                  )
                   : mosqueProvider.showEid
-                      ? SalahItemWidget(
-                          title: "Salat El Eid",
-                          iqama: mosqueProvider.times!.aidPrayerTime2,
-                          time: mosqueProvider.times!.aidPrayerTime ?? "",
-                          removeBackground: false,
-                          withDivider: mosqueProvider.times!.aidPrayerTime2 != null,
-                          active: true,
-                        )
-                      : SalahItemWidget(
-                          title: S.of(context).shuruk,
-                          time: mosqueProvider.times!.shuruq ?? "",
-                          removeBackground: true,
-                          withDivider: false,
-                          active: mosqueProvider.activateShroukItem,
-                        ),
+                      ? Center(
+                        child: SalahItemWidget(
+                            title: "Salat El Eid",
+                            iqama: mosqueProvider.times!.aidPrayerTime2,
+                            time: mosqueProvider.times!.aidPrayerTime ?? "",
+                            removeBackground: false,
+                            withDivider: mosqueProvider.times!.aidPrayerTime2 != null,
+                            active: true,
+                          ),
+                      )
+                      : Center(
+                        child: SalahItemWidget(
+                            title: S.of(context).shuruk,
+                            time: mosqueProvider.times!.shuruq ?? "",
+                            removeBackground: true,
+                            withDivider: false,
+                            active: mosqueProvider.activateShroukItem,
+                          ),
+                      ),
             ),
             HomeTimeWidget(),
             Expanded(
-              child: SalahItemWidget(
-                title: S.of(context).jumua,
-                time: mosqueProvider.times!.jumua ?? "",
-                iqama: mosqueProvider.times!.jumua2,
-                active:
-                    mosqueProvider.nextSalahIndex() == 2 && mosqueProvider.mosqueDate().weekday == DateTime.friday,
-                removeBackground: true,
+              child: Center(
+                child: SalahItemWidget(
+                  title: S.of(context).jumua,
+                  time: mosqueProvider.times!.jumua ?? "",
+                  iqama: mosqueProvider.times!.jumua2,
+                  active:
+                      mosqueProvider.nextSalahIndex() == 2 && mosqueProvider.mosqueDate().weekday == DateTime.friday,
+                  removeBackground: true,
+                ),
               ),
             ),
           ],

--- a/lib/src/pages/home/widgets/SalahItem.dart
+++ b/lib/src/pages/home/widgets/SalahItem.dart
@@ -32,12 +32,17 @@ class SalahItemWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    double bigFont = 4.vw;
+    double smallFont = 3.vw;
+
     final mosqueProvider = context.watch<MosqueManager>();
     final mosqueConfig = mosqueProvider.mosqueConfig;
-
+    bool? isIqamaEnabled = mosqueConfig?.iqamaEnabled!;
+    bool? isIqamaMoreImportant = mosqueConfig!.iqamaMoreImportant!&&isIqamaEnabled! ;
     final timeDate = time.toTimeOfDay()?.toDate();
     final iqamaDate = iqama?.toTimeOfDay()?.toDate();
-    final DateFormat dateTimeConverter = mosqueConfig?.timeDisplayFormat == "12"
+    print (isIqamaEnabled);
+    final DateFormat dateTimeConverter = mosqueConfig.timeDisplayFormat == "12"
         ? DateFormat(
             "hh:mm",
             "en-En",
@@ -46,7 +51,7 @@ class SalahItemWidget extends StatelessWidget {
             "HH:mm",
             "en",
           );
-    final DateFormat dateTimePeriodConverter = mosqueConfig?.timeDisplayFormat == "12"
+    final DateFormat dateTimePeriodConverter = mosqueConfig.timeDisplayFormat == "12"
         ? DateFormat(
             "a",
             "en",
@@ -89,7 +94,7 @@ class SalahItemWidget extends StatelessWidget {
                 Text(
                   timeDate == null ? time : dateTimeConverter.format(timeDate),
                   style: TextStyle(
-                    fontSize: 3.8.vw,
+                    fontSize: isIqamaMoreImportant! ? smallFont : bigFont,
                     fontWeight: FontWeight.w700,
                     shadows: kHomeTextShadow,
                     color: Colors.white,
@@ -112,13 +117,16 @@ class SalahItemWidget extends StatelessWidget {
                   ),
               ],
             ),
-            if (iqama != null)
+            if (iqama != null &&isIqamaEnabled!)
               SizedBox(
                 height: 1.3.vw,
                 width: double.infinity,
-                child: Divider(thickness: 1, color: withDivider ? Colors.white : Colors.transparent),
+                child: Divider(
+                  thickness: 1,
+                  color: withDivider ? Colors.white : Colors.transparent,
+                ),
               ),
-            if (iqama != null)
+            if (iqama != null&&isIqamaEnabled!)
               Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
@@ -126,14 +134,18 @@ class SalahItemWidget extends StatelessWidget {
                     iqamaDate == null ? iqama! : dateTimeConverter.format(iqamaDate),
                     // '$iqama${iqama!.startsWith('+') ? "\'" : ""}',
                     style: TextStyle(
-                      fontSize: 3.vw,
+                      fontSize: isIqamaMoreImportant ? bigFont : smallFont,
                       fontWeight: FontWeight.bold,
                       shadows: kHomeTextShadow,
                       letterSpacing: 1,
                       color: Colors.white,
                     ),
                   ),
+<<<<<<< Updated upstream
                   if (iqamaDate != null)
+=======
+                  if (iqamaDate != null )
+>>>>>>> Stashed changes
                     SizedBox(
                       width: 1.vw,
                       child: Text(

--- a/lib/src/services/audio_manager.dart
+++ b/lib/src/services/audio_manager.dart
@@ -4,9 +4,11 @@ import 'package:mawaqit/src/models/mosqueConfig.dart';
 
 class AudioManager extends ChangeNotifier {
   String adhanLink = "https://mawaqit.net/static/mp3/adhan-afassy.mp3";
+  String bipLink = "https://mawaqit.net/static/mp3/bip.mp3";
   String duaAfterAdhanLink = "https://mawaqit.net/static/mp3/duaa-after-adhan.mp3";
   late Audio adhan;
   late Audio duaAfterAdhan;
+  late Audio bip;
 
   void loadAdhanVoice(MosqueConfig? mosqueConfig) {
     if (mosqueConfig!.adhanVoice != null && mosqueConfig.adhanVoice!.isNotEmpty) {
@@ -17,12 +19,28 @@ class AudioManager extends ChangeNotifier {
       onComplete: () {
         adhan.dispose();
         adhan.pause();
-        print("onComplete voice ");
       },
       onError: (message) {
         print("error$message");
       },
     )!;
+  }
+
+  void loadAndPlayIqamaBipVoice(MosqueConfig? mosqueConfig) {
+    if (mosqueConfig!.iqamaBip) {
+      adhanLink = "https://mawaqit.net/static/mp3/${mosqueConfig.adhanVoice!}.mp3";
+      bip = Audio.loadFromRemoteUrl(
+        bipLink,
+        onComplete: () {
+          bip.dispose();
+          bip.pause();
+        },
+        onError: (message) {
+          print("error$message");
+        },
+      )!;
+      bip.play();
+    }
   }
 
   void loadDuaAfterAdhanVoice(MosqueConfig? mosqueConfig) {

--- a/lib/src/services/mosque_manager.dart
+++ b/lib/src/services/mosque_manager.dart
@@ -20,12 +20,10 @@ import 'audio_mixin.dart';
 final mawaqitApi = "https://mawaqit.net/api/2.0";
 
 const kAfterAdhanHadithDuration = Duration(minutes: 1);
-const kIqamaaDuration = Duration(seconds: 37);
 const kAdhanBeforeFajrDuration = Duration(minutes: 10);
 
 const kAzkarDuration = Duration(minutes: 2);
 
-const salahDuration = Duration(minutes: 10);
 
 class MosqueManager extends ChangeNotifier with WeatherMixin, AudioMixin {
   final sharedPref = SharedPref();
@@ -211,6 +209,12 @@ class MosqueManager extends ChangeNotifier with WeatherMixin, AudioMixin {
 
 extension MosqueHelperUtils on MosqueManager {
   calculateActiveScreen() {
+    Duration iqamaaDuration = Duration(seconds: mosqueConfig!.iqamaDisplayTime!);
+    print (iqamaaDuration);
+
+
+
+
     /// still user didn't select his mosque
     if (mosque == null || times == null) return;
     // normal screen in announcement screen
@@ -224,6 +228,9 @@ extension MosqueHelperUtils on MosqueManager {
     final nextIqamaIndex = this.nextIqamaIndex();
     final lastIqamaIndex = salahIndex;
     final lastIqama = actualIqamaTimes()[lastIqamaIndex];
+    int salahMinute = int.parse(mosqueConfig!.duaAfterPrayerShowTimes[lastSalahIndex]);
+     Duration salahDuration = Duration(minutes:salahMinute);
+     print (salahMinute);
     if (actualTimes()[0].subtract(kAdhanBeforeFajrDuration).difference(now).abs() < (getAdhanDuration(mosqueConfig)) &&
         mosqueConfig?.wakeForFajrTime != null) {
       state = HomeActiveScreen.adhan;
@@ -236,7 +243,7 @@ extension MosqueHelperUtils on MosqueManager {
         mosqueConfig!.duaAfterAzanEnabled!) {
       /// adhan has just done
       state = HomeActiveScreen.afterAdhanHadith;
-    } else if (lastIqama.difference(now).abs() < kIqamaaDuration) {
+    } else if (lastIqama.difference(now).abs() < iqamaaDuration&&mosqueConfig!.iqamaEnabled!) {
       /// we are in iqama time
       state = HomeActiveScreen.iqamaa;
     } else if (nextIqamaIndex == lastSalahIndex) {
@@ -245,10 +252,10 @@ extension MosqueHelperUtils on MosqueManager {
         ///todo handle jumuaa live when url is ready
         state = HomeActiveScreen.jumuaaHadith;
         // state = HomeActiveScreen.jumuaaLiveScreen;
-      } else {
+      } else if (mosqueConfig!.iqamaFullScreenCountdown!) {
         state = HomeActiveScreen.iqamaaCountDown;
       }
-    } else if ((now.difference(lastIqama) - salahDuration).abs() < kAzkarDuration) {
+    } else if ((now.difference(lastIqama) - salahDuration).abs() < kAzkarDuration&&mosqueConfig!.iqamaEnabled!) {
       state = HomeActiveScreen.afterSalahAzkar;
     }
 

--- a/lib/src/services/weather_mixin.dart
+++ b/lib/src/services/weather_mixin.dart
@@ -34,8 +34,8 @@ mixin WeatherMixin on ChangeNotifier {
       case "cold":
         color = "#FFFFFF";
         return color;
-      case " very-cold":
-        color = "";
+      case "very-cold":
+        color = "#3498db";
         return color;
     }
     return color;


### PR DESCRIPTION
solve #304 

- When iqama is disabled don't show iqama time and don't display after iqama screens (black screen - dua after salah screen)
- When the  black screen is disabled show the normal screen 
- When the dua after salah disabled show normal home 
- When iqama bip is enabled, play bip sound
- When iqamCountDown is enabled, show the iqama countdown screen 
- When iqamaIsMoreImportant enable show iqama time text bigger than salah time 
![Screenshot (288)](https://user-images.githubusercontent.com/75434006/211968512-b11f701c-0859-4247-af50-89b9fa310c48.png)

- Add Salah duration based on (the estimated duration of each prayer )
![Untitled](https://user-images.githubusercontent.com/75434006/211965046-30dd6d38-00ab-4a2d-8131-8eb23db425e3.png)
