### PR TITLE
precache all voices when user select his mosque

### DIFF
--- a/lib/src/services/mosque_manager.dart
+++ b/lib/src/services/mosque_manager.dart
@@ -10,6 +10,7 @@ import 'package:mawaqit/src/helpers/SharedPref.dart';
 import 'package:mawaqit/src/models/mosque.dart';
 import 'package:mawaqit/src/models/mosqueConfig.dart';
 import 'package:mawaqit/src/models/times.dart';
+import 'package:mawaqit/src/services/audio_manager.dart';
 import 'package:mawaqit/src/services/mixins/mosque_helpers_mixins.dart';
 import 'package:mawaqit/src/services/mixins/weather_mixin.dart';
 
@@ -129,7 +130,8 @@ class MosqueManager extends ChangeNotifier
       notifyListeners();
     });
 
-    _configSubscription = Api.getMosqueConfigStream(uuid).listen((event) {
+    _configSubscription = Api.getMosqueConfigStream(uuid).listen((event) async {
+      await AudioManager().precacheVoices(event).catchError((e) {});
       mosqueConfig = event;
       notifyListeners();
 
@@ -147,7 +149,8 @@ class MosqueManager extends ChangeNotifier
     return completer.future;
   }
 
-  Future<Mosque> searchMosqueWithId(String mosqueId) => Api.searchMosqueWithId(mosqueId);
+  Future<Mosque> searchMosqueWithId(String mosqueId) =>
+      Api.searchMosqueWithId(mosqueId);
 
   Future<List<Mosque>> searchMosques(String mosque, {page = 1}) async =>
       Api.searchMosques(mosque, page: page);


### PR DESCRIPTION
### Voices 
1. Adhan 
2. Fajr adhan 
3. Bip sound
4. after adhan duaa 

### Cached when 
1. When the user selects/changes his mosque 
5. When the user changes the configuration on the backend 

### Notice
1. for caching we use the voice URL so 
1. Chched values will not be cached again 
   1. if he cached the adhan and didn't change it 
    2.  If He changed a mosque but the new mosque uses the same adhan as the old one 


