### PR TITLE
refactor salah workflow

### DIFF
--- a/lib/src/developer_mode/DrawerListTest.dart
+++ b/lib/src/developer_mode/DrawerListTest.dart
@@ -4,7 +4,6 @@ import 'package:mawaqit/src/pages/HomeScreen.dart';
 import 'package:mawaqit/src/pages/developer/DeveloperScreen.dart';
 import 'package:provider/provider.dart';
 
-import 'AnnouncementTest.dart';
 import '../elements/DrawerListTitle.dart';
 import '../helpers/AppRouter.dart';
 import '../pages/home/sub_screens/AdhanSubScreen.dart';
@@ -17,6 +16,7 @@ import '../pages/home/sub_screens/JumuaHadithSubScreen.dart';
 import '../pages/home/sub_screens/RandomHadithScreen.dart';
 import '../pages/home/sub_screens/normal_home.dart';
 import '../pages/home/widgets/mosque_background_screen.dart';
+import 'AnnouncementTest.dart';
 
 class DrawerListDeveloper extends StatelessWidget {
   const DrawerListDeveloper({Key? key}) : super(key: key);

--- a/lib/src/helpers/Api.dart
+++ b/lib/src/helpers/Api.dart
@@ -58,7 +58,6 @@ class Api {
   static Future<Mosque> getMosque(String id) async {
     final response = await dio.get('/mosque/$id/info');
 
-    print(response.data);
     return Mosque.fromMap(response.data);
   }
 

--- a/lib/src/pages/home/OfflineHomeScreen.dart
+++ b/lib/src/pages/home/OfflineHomeScreen.dart
@@ -6,6 +6,7 @@ import 'package:mawaqit/src/helpers/AppRouter.dart';
 import 'package:mawaqit/src/helpers/HiveLocalDatabase.dart';
 import 'package:mawaqit/src/pages/ErrorScreen.dart';
 import 'package:mawaqit/src/pages/MosqueSearchScreen.dart';
+import 'package:mawaqit/src/pages/home/widgets/WorkFlowWidget.dart';
 import 'package:mawaqit/src/pages/home/widgets/mosque_background_screen.dart';
 import 'package:mawaqit/src/pages/home/workflow/jumua_workflow_screen.dart';
 import 'package:mawaqit/src/pages/home/workflow/normal_workflow.dart';
@@ -72,7 +73,7 @@ class OfflineHomeScreen extends StatelessWidget {
           Navigator.pop(context);
           return false;
         }
- 
+
         return await showClosingDialog(context) ?? false;
       },
       child: MosqueBackgroundScreen(

--- a/lib/src/pages/home/sub_screens/AdhanSubScreen.dart
+++ b/lib/src/pages/home/sub_screens/AdhanSubScreen.dart
@@ -31,12 +31,9 @@ class AdhanSubScreen extends StatefulWidget {
 
 class _AdhanSubScreenState extends State<AdhanSubScreen> {
   AudioManager? audioManager;
-  Future minimumDelay = Future.delayed(2.minutes);
 
   /// if mosque using Beb sound we will wait for minutes delay
   closeAdhanScreen() async {
-    await minimumDelay;
-
     widget.onDone?.call();
   }
 

--- a/lib/src/pages/home/sub_screens/AfterSalahAzkarScreen.dart
+++ b/lib/src/pages/home/sub_screens/AfterSalahAzkarScreen.dart
@@ -52,6 +52,7 @@ class _AfterSalahAzkarState extends State<AfterSalahAzkar> {
 
   String translatedItem(int index) {
     index %= 7;
+
     switch (index) {
       case 0:
         return S.of(context).azkarList0;

--- a/lib/src/pages/home/sub_screens/DuaaBetweenAdhanAndIqama.dart
+++ b/lib/src/pages/home/sub_screens/DuaaBetweenAdhanAndIqama.dart
@@ -27,8 +27,12 @@ class _DuaaBetweenAdhanAndIqamaaScreenState
   @override
   void initState() {
     final manager = context.read<MosqueManager>();
+    final nextIqamaa = manager.nextIqamaaAfter();
 
-    if (manager.mosqueConfig!.duaAfterAzanEnabled!)
+    bool skipDuaa = nextIqamaa < Duration(seconds: 30) ||
+        nextIqamaa > Duration(minutes: 30);
+
+    if (manager.mosqueConfig!.duaAfterAzanEnabled! && !skipDuaa)
       Future.delayed(30.seconds, widget.onDone);
     else
       Future.delayed(80.milliseconds, widget.onDone);

--- a/lib/src/pages/home/sub_screens/IqamaaCountDownSubScreen.dart
+++ b/lib/src/pages/home/sub_screens/IqamaaCountDownSubScreen.dart
@@ -1,6 +1,7 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
-import 'package:mawaqit/i18n/AppLanguage.dart';
 import 'package:mawaqit/i18n/l10n.dart';
 import 'package:mawaqit/src/helpers/RelativeSizes.dart';
 import 'package:mawaqit/src/helpers/StringUtils.dart';
@@ -13,35 +14,56 @@ import 'package:mawaqit/src/services/mosque_manager.dart';
 import 'package:mawaqit/src/themes/UIShadows.dart';
 import 'package:provider/provider.dart';
 
-import '../../../enum/connectivity_status.dart';
 import '../../../helpers/time_utils.dart';
 
-class IqamaaCountDownSubScreen extends StatelessWidget {
+class IqamaaCountDownSubScreen extends StatefulWidget {
   const IqamaaCountDownSubScreen({Key? key, this.onDone}) : super(key: key);
 
   final VoidCallback? onDone;
 
   @override
-  Widget build(BuildContext context) {
+  State<IqamaaCountDownSubScreen> createState() =>
+      _IqamaaCountDownSubScreenState();
+}
+
+class _IqamaaCountDownSubScreenState extends State<IqamaaCountDownSubScreen> {
+  StreamSubscription? _streamSubscription;
+
+  @override
+  void initState() {
     final mosqueManager = context.read<MosqueManager>();
-    final isArabic = context.read<AppLanguage>().isArabic();
-    final nextIqamaIndex = mosqueManager.nextIqamaIndex();
-    var nextIqamaTime = mosqueManager.actualIqamaTimes()[nextIqamaIndex];
-    var connectionStatus = Provider.of<ConnectivityStatus>(context);
-    bool isOffline = connectionStatus == ConnectivityStatus.Offline;
-    final tr = S.of(context);
-    if (nextIqamaTime.isBefore(mosqueManager.mosqueDate())) {
-      nextIqamaTime = nextIqamaTime.add(Duration(days: 1));
+    final nextIqamaa = mosqueManager.nextIqamaaAfter();
+
+    if (nextIqamaa <= Duration.zero || nextIqamaa > Duration(minutes: 30)) {
+      Future.delayed(Duration(milliseconds: 80), widget.onDone);
+    } else {
+      Future.delayed(nextIqamaa, widget.onDone);
     }
 
-    if (mosqueManager.mosqueConfig?.iqamaFullScreenCountdown == false)
-      return FutureBuilder(
-        future: Future.delayed(
-            nextIqamaTime.difference(mosqueManager.mosqueDate()), onDone),
-        builder: (context, snapshot) => NormalHomeSubScreen(),
-      );
+    _streamSubscription = Stream.periodic(Duration(seconds: 1)).listen((event) {
+      setState(() {});
+    });
+    super.initState();
+  }
 
-    return Stack(
+
+  @override
+  void dispose() {
+    _streamSubscription?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final mosqueManager = context.read<MosqueManager>();
+    final nextIqama = mosqueManager.nextIqamaaAfter();
+
+    final tr = S.of(context);
+
+    if (mosqueManager.mosqueConfig?.iqamaFullScreenCountdown == false)
+      return NormalHomeSubScreen();
+
+    return Column(
       children: [
         Row(
           textDirection: TextDirection.ltr,
@@ -55,52 +77,46 @@ class IqamaaCountDownSubScreen extends StatelessWidget {
             )
           ],
         ),
-        Column(
-          children: [
-            SizedBox(height: isArabic ? 1.vh : 4.vh),
-            Text(
-              tr.iqamaIn,
-              style: TextStyle(
-                  fontSize: 7.vw,
-                  color: Colors.white,
-                  fontWeight: FontWeight.bold,
-                  shadows: kIqamaCountDownTextShadow,
-                  fontFamily: StringManager.getFontFamilyByString(tr.iqamaIn)),
-            ).animate().slide(delay: .5.seconds).fade().addRepaintBoundary(),
-            Expanded(
-              child: StreamBuilder(
-                  stream: Stream.periodic(Duration(seconds: 1)),
-                  builder: (context, snapshot) {
-                    final remaining =
-                        nextIqamaTime.difference(mosqueManager.mosqueDate());
-                    if (remaining <= Duration.zero) {
-                      Future.delayed(Duration(milliseconds: 80), onDone);
-                    }
+        Text(
+          tr.iqamaIn,
+          style: TextStyle(
+              fontSize: 7.vw,
+              color: Colors.white,
+              fontWeight: FontWeight.bold,
+              shadows: kIqamaCountDownTextShadow,
+              fontFamily: StringManager.getFontFamilyByString(tr.iqamaIn)),
+        ).animate().slide(delay: .5.seconds).fade().addRepaintBoundary(),
+        Expanded(
+          child: StreamBuilder(
+              stream: Stream.periodic(Duration(seconds: 1)),
+              builder: (context, snapshot) {
+                final remaining = nextIqama;
+                if (remaining <= Duration.zero) {
+                  Future.delayed(Duration(milliseconds: 80), widget.onDone);
+                }
 
-                    int seconds = remaining.inSeconds % 60;
-                    int minutes = remaining.inMinutes;
-                    String _timeTwoDigit = timeTwoDigit(
-                      seconds: seconds,
-                      minutes: minutes,
-                    );
-                    return Text(
-                      _timeTwoDigit,
-                      style: TextStyle(
-                        fontSize: 25.vw,
-                        color: Colors.white,
-                        fontWeight: FontWeight.w500,
-                        shadows: kIqamaCountDownTextShadow,
-                      ),
-                    )
-                        .animate()
-                        .fadeIn(delay: .7.seconds, duration: 2.seconds)
-                        .addRepaintBoundary();
-                  }),
-            ),
-            SalahTimesBar(miniStyle: true),
-            SizedBox(height: 10),
-          ],
+                int seconds = remaining.inSeconds % 60;
+                int minutes = remaining.inMinutes;
+                String _timeTwoDigit = timeTwoDigit(
+                  seconds: seconds,
+                  minutes: minutes,
+                );
+                return Text(
+                  _timeTwoDigit,
+                  style: TextStyle(
+                    fontSize: 25.vw,
+                    color: Colors.white,
+                    fontWeight: FontWeight.w500,
+                    shadows: kIqamaCountDownTextShadow,
+                  ),
+                )
+                    .animate()
+                    .fadeIn(delay: .7.seconds, duration: 2.seconds)
+                    .addRepaintBoundary();
+              }),
         ),
+        SalahTimesBar(miniStyle: true),
+        SizedBox(height: 10),
       ],
     );
   }

--- a/lib/src/pages/home/sub_screens/normal_home.dart
+++ b/lib/src/pages/home/sub_screens/normal_home.dart
@@ -20,7 +20,6 @@ class NormalHomeSubScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final mosqueProvider = context.read<MosqueManager>();
     final mosque = mosqueProvider.mosque!;
-    final mosqueConfig = mosqueProvider.mosqueConfig;
 
     return Column(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -53,9 +52,7 @@ class NormalHomeSubScreen extends StatelessWidget {
             ],
           ),
         ),
-        Spacer(),
         SalahTimesBar(),
-        Spacer(),
         Footer(),
       ],
     );

--- a/lib/src/pages/home/widgets/WorkFlowWidget.dart
+++ b/lib/src/pages/home/widgets/WorkFlowWidget.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+
+class WorkFlowItem {
+  final Widget Function(BuildContext context, VoidCallback next) builder;
+
+  /// this this item on the initial start of the workflow
+  /// this used to calculate the first item to show in the workflow
+  final bool skip;
+  final Duration? duration;
+  final bool disabled;
+
+  /// this is the minimum duration of the item
+  /// if the item calls [next] before the minimum duration
+  /// the item will wait for the minimum duration to finish
+  final Duration? minimumDuration;
+
+  WorkFlowItem({
+    required this.builder,
+    this.skip = false,
+    this.duration,
+    this.minimumDuration,
+    this.disabled = false,
+  });
+}
+
+/// this widget is used to show a workflow of screens
+/// can handle only continuous workflows like the salah workflow
+class ContinuesWorkFlowWidget extends StatefulWidget {
+  const ContinuesWorkFlowWidget({
+    super.key,
+    required this.workFlowItems,
+    this.onDone,
+  });
+
+  final List<WorkFlowItem> workFlowItems;
+  final void Function()? onDone;
+
+  @override
+  State<ContinuesWorkFlowWidget> createState() =>
+      _ContinuesWorkFlowWidgetState();
+}
+
+class _ContinuesWorkFlowWidgetState extends State<ContinuesWorkFlowWidget> {
+  Future? minimumDurationFuture;
+  int _currentItemIndex = 0;
+
+  WorkFlowItem activeItem() {
+    return widget.workFlowItems[_currentItemIndex];
+  }
+
+  getInitialItem() {
+    for (var i = 0; i < widget.workFlowItems.length; i++) {
+      final workflowItem = widget.workFlowItems[i];
+      if (workflowItem.skip) continue;
+
+      _currentItemIndex = i - 1;
+      nextPage();
+      return;
+    }
+  }
+
+  nextPage() async {
+    if (_currentItemIndex >= widget.workFlowItems.length - 1) {
+      widget.onDone?.call();
+      return;
+    }
+
+    _currentItemIndex++;
+
+    if (activeItem().disabled) return nextPage();
+
+    if (minimumDurationFuture != null) await minimumDurationFuture;
+
+    setState(() {
+      if (activeItem().minimumDuration != null)
+        minimumDurationFuture = Future.delayed(activeItem().minimumDuration!);
+    });
+
+    if (activeItem().duration != null)
+      Future.delayed(activeItem().duration!, nextPage);
+  }
+
+  @override
+  void initState() {
+    getInitialItem();
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_currentItemIndex < 0) return Container();
+    return activeItem().builder(context, nextPage);
+  }
+}

--- a/lib/src/services/mixins/mosque_helpers_mixins.dart
+++ b/lib/src/services/mixins/mosque_helpers_mixins.dart
@@ -123,7 +123,7 @@ mixin MosqueHelpersMixin on ChangeNotifier {
           todayIqama[i]
               .toTimeOfDay(
                 tryOffset: todayTimes[i].toTimeOfDay()!.toDate(mosqueDate()),
-                minimumMinutes: 3,
+                // minimumMinutes: 3,
               )!
               .toDate(mosqueDate()),
       ];
@@ -163,8 +163,12 @@ mixin MosqueHelpersMixin on ChangeNotifier {
   }
 
   /// the duration until the next salah
-  Duration nextIqamaaAfter() =>
-      actualIqamaTimes()[nextIqamaIndex()].difference(mosqueDate());
+  Duration nextIqamaaAfter() {
+    final value = actualIqamaTimes()[nextIqamaIndex()].difference(mosqueDate());
+
+    if (value < Duration.zero) return value + Duration(days: 1);
+    return value;
+  }
 
   /// return actual salah duration
   Duration get currentSalahDuration {
@@ -205,9 +209,8 @@ mixin MosqueHelpersMixin on ChangeNotifier {
   DateTime mosqueDate() => !kDebugMode
       ? DateTime.now()
       : DateTime.now().add(Duration(
-          days: 3,
-          hours: 13,
-          minutes: 10 + 10,
+          hours: 19,
+          minutes: -19-6,
         ));
 
   /// used to test time


### PR DESCRIPTION
1. Salah workflow code optimize 


Test cases 
- [ ] adhan voice-enabled/disabled/Bep (should stay at least 2min)
- [ ] after adhan duaa enable/disabled
- [ ] after adhan duaa voice should match the adhan 
- [ ] Duaa between adhan and iqama work when (after adhan enabled & there is enough time until next iqama 30 at least)
- [ ] Iqama countdown enabled/disabled
- [ ] Iqama count can't have more than 30min if the next iqama is more than 30 min that means iqama time started 
- [ ] Iqama screen can be enabled/disabled and should disable all the screens from the iqama count down and forward
- [ ] show black screen during salah time 
- [ ] After salah azkar will be at the end of the list
- [ ] If iqama is set to +0 the iqama will be shown immediately after the (adhan, after adhan duaa)

@ibrahim-zehhaf-mawaqit If there are any other test cases please add them to the list so I test them and test them in the future 