### PR TITLE
Update MawaqitHijriCalendar.dart

### DIFF
--- a/lib/src/models/MawaqitHijriCalendar.dart
+++ b/lib/src/models/MawaqitHijriCalendar.dart
@@ -13,7 +13,7 @@ class MawaqitHijriCalendar extends HijriCalendar {
     bool force30Days = false,
   }) {
     var hijri = MawaqitHijriCalendar.fromDate(
-      date.add(Duration(days: adjustment)),
+      date.add(Duration(days: adjustment + 1)),
     );
 
     if (force30Days) hijri.hDay = 30;


### PR DESCRIPTION
There is a difference between the way the Hijri date is calculated on Android TV and Backend 

Fixes this by adding a +1 into the incoming difference from the backed 