### PR TITLE
fix eid display times

### DIFF
--- a/lib/src/services/mixins/mosque_helpers_mixins.dart
+++ b/lib/src/services/mixins/mosque_helpers_mixins.dart
@@ -109,9 +109,9 @@ mixin MosqueHelpersMixin on ChangeNotifier {
       return false;
 
     final date = mosqueHijriDate();
-    return (((date.islamicMonth == 9 && date.islamicDate! >= 23) ||
-            (date.islamicMonth == 10 && date.islamicDate! == 1)) ||
-        (date.islamicMonth == 12 && date.islamicDate! < 11));
+    return (date.islamicMonth == 8 && date.islamicDate >= 23) ||
+        (date.islamicMonth == 9 && date.islamicDate == 1) ||
+        (date.islamicMonth == 11 && date.islamicDate < 11 && date.islamicDate >= 3);
   }
 
   /// get today salah prayer times as a list of times


### PR DESCRIPTION
### Issue 

After changing the way hijri date is calculated this issue appears because in the old way months start counting from 1

### Fix 
Fixed by removing 1 from the months on the showEid getter method 

### Current logic 
First eid 
- will be shown from 23 Ramadan until 1 shawsal (included)
Second eid 
- will be shown from 3 Du elhega until 10 Du elhega (included)