### PR TITLE
Handle error case on the announcement video

### DIFF
--- a/lib/src/pages/home/sub_screens/AnnouncementScreen.dart
+++ b/lib/src/pages/home/sub_screens/AnnouncementScreen.dart
@@ -150,22 +150,26 @@ class _AnnouncementScreenState extends State<AnnouncementScreen> {
 
   Widget videoAnnouncement(String video) {
     late YoutubePlayerController _controller = YoutubePlayerController(
-      initialVideoId: YoutubePlayer.convertUrlToId(
-        video,
-      )!,
-      flags: YoutubePlayerFlags(
-        autoPlay: true,
-        mute: true,
-      ),
+      initialVideoId: YoutubePlayer.convertUrlToId(video)!,
+      flags: YoutubePlayerFlags(autoPlay: true, mute: true),
     );
-    return Container(
-      width: double.infinity,
-      height: double.infinity,
-      child: YoutubePlayer(
-        onEnded: (metaData) => nextAnnouncement(),
-        controller: _controller,
-        showVideoProgressIndicator: true,
-      ),
+    return FutureBuilder(
+      future: Future.delayed(20.seconds),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.done) {
+          /// if the video is not loaded in 20 seconds, go to the next announcement
+          if (_controller.value.isReady == false) nextAnnouncement();
+        }
+        return Container(
+          width: double.infinity,
+          height: double.infinity,
+          child: YoutubePlayer(
+            onEnded: (metaData) => nextAnnouncement(),
+            controller: _controller,
+            showVideoProgressIndicator: true,
+          ),
+        );
+      },
     );
   }
 

--- a/lib/src/services/mixins/mosque_helpers_mixins.dart
+++ b/lib/src/services/mixins/mosque_helpers_mixins.dart
@@ -20,6 +20,10 @@ mixin MosqueHelpersMixin on ChangeNotifier {
 
   abstract HomeActiveWorkflow workflow;
 
+  /// this will be set from the [NetworkConnectivity] mixin
+  /// because we use in the [activeAnnouncements] getter
+  bool get isOnline;
+
   salahName(int index) => [
         S.current.fajr,
         S.current.duhr,
@@ -111,7 +115,9 @@ mixin MosqueHelpersMixin on ChangeNotifier {
     final date = mosqueHijriDate();
     return (date.islamicMonth == 8 && date.islamicDate >= 23) ||
         (date.islamicMonth == 9 && date.islamicDate == 1) ||
-        (date.islamicMonth == 11 && date.islamicDate < 11 && date.islamicDate >= 3);
+        (date.islamicMonth == 11 &&
+            date.islamicDate < 11 &&
+            date.islamicDate >= 3);
   }
 
   /// get today salah prayer times as a list of times
@@ -358,7 +364,13 @@ mixin MosqueHelpersMixin on ChangeNotifier {
       final inTime = now.isAfter(startDate ?? DateTime(2000)) &&
           now.isBefore(endDate ?? DateTime(3000));
 
-      return (element.video == null || !typeIsMosque) && inTime;
+      /// on offline mode we don't show videos
+      if (element.video != null && !isOnline) return false;
+
+      /// on mosque screen we don't show videos
+      if (element.video != null && typeIsMosque) return false;
+
+      return inTime;
     }).toList();
   }
 }


### PR DESCRIPTION
This issue will happen in most cases because the mosque is using the app in offline mode 

To Skip it I added two conditions 
1. we aren't showing video announcements in offline mode 
2. I check after 20 sec if the video isn't started for any reason the app will go to the next announcement 