### PR TITLE
fix v7 crashes

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -80,6 +80,11 @@ android {
     release {
       signingConfig signingConfigs.release
 
+      ndk{
+        abiFilters 'armeabi-v7a'
+      }
+
+
       flavorDimensions "app-type"
 
       productFlavors {


### PR DESCRIPTION
This issue happened because Flutter didn't add its own engine the built apk 

This issue was fixed by building only for armeabi-v7a Api 

The build apk will be runnable on arm64-v8a architecture

both  armeabi-v7a, arm64-v8a are almost 99% of the devices 
So we know support 99% of android devices


Please check out the app performance on your box to be sure this step does not affect on the performance 