### PR TITLE
fix workflow setstate issue

### DIFF
--- a/lib/src/pages/home/widgets/workflows/WorkFlowWidget.dart
+++ b/lib/src/pages/home/widgets/workflows/WorkFlowWidget.dart
@@ -40,8 +40,7 @@ class ContinuesWorkFlowWidget extends StatefulWidget {
   final void Function()? onDone;
 
   @override
-  State<ContinuesWorkFlowWidget> createState() =>
-      _ContinuesWorkFlowWidgetState();
+  State<ContinuesWorkFlowWidget> createState() => _ContinuesWorkFlowWidgetState();
 }
 
 class _ContinuesWorkFlowWidgetState extends State<ContinuesWorkFlowWidget> {
@@ -72,6 +71,10 @@ class _ContinuesWorkFlowWidgetState extends State<ContinuesWorkFlowWidget> {
     if (_currentItemIndex != this._currentItemIndex) return;
     delayedNextPageFuture?.ignore();
 
+    /// if the widget removed from the tree
+    /// no need for [nextPage]
+    if (!mounted) return;
+
     if (_currentItemIndex >= widget.workFlowItems.length - 1) {
       /// we adding this delay to make sure flutter called the build function
       /// if flutter didn't called the build any navigation login inside the [ContinuesWorkFlowWidget.onDone] will be ignored
@@ -84,8 +87,7 @@ class _ContinuesWorkFlowWidgetState extends State<ContinuesWorkFlowWidget> {
 
     if (activeItem().disabled) return nextPage(this._currentItemIndex);
 
-    if (activeItem().minimumDuration != null)
-      minimumDurationFuture = Future.delayed(activeItem().minimumDuration!);
+    if (activeItem().minimumDuration != null) minimumDurationFuture = Future.delayed(activeItem().minimumDuration!);
 
     if (activeItem().duration != null) {
       delayedNextPageFuture = Future.delayed(activeItem().duration!);

--- a/lib/src/pages/home/widgets/workflows/repeating_workflow_widget.dart
+++ b/lib/src/pages/home/widgets/workflows/repeating_workflow_widget.dart
@@ -9,7 +9,9 @@ class RepeatingWorkflowItem {
 
   /// this item ending time
   /// if set the item will be in that time
-  /// this can be used instead of [duration] in case need to in specific time
+  /// this can be used instead of [duration] in case need to in specific time the item will be forced to end in that time
+  /// - in case of [duration] if item start after the [dateTime] it will end in [startTime] + [duration]
+  /// - in case of [endTime] if item start after the [dateTime] it will end in [endTime]
   final DateTime? endTime;
 
   /// if set the item will be repeated every [repeatingDuration]
@@ -55,7 +57,6 @@ class RepeatingWorkflowItem {
 
 /// handle workflows that its item isn't shown one after another
 /// TODO: This will be used in the future to handle the active workflow
-/// TODO: this will be used to handle the normal workflow transitions
 class RepeatingWorkFlowWidget extends StatefulWidget {
   const RepeatingWorkFlowWidget({Key? key, this.child, this.items = const []}) : super(key: key);
 
@@ -100,6 +101,10 @@ class _RepeatingWorkFlowWidgetState extends State<RepeatingWorkFlowWidget> {
 
   /// active item with index
   startItem(int itemIndex) {
+    /// if widget is removed from the tree
+    /// no need for this
+    if (!mounted) return;
+
     final item = widget.items[itemIndex];
 
     if (item.disabled) return;
@@ -125,7 +130,10 @@ class _RepeatingWorkFlowWidgetState extends State<RepeatingWorkFlowWidget> {
   /// called when the item is done from the item builder or after the duration
   /// if the [itemIndex] isn't equal to the [activeItem] will do nothing
   onItemDone(int itemIndex) async {
-    print('onItemDone: $itemIndex');
+    /// if widget is removed from the tree
+    /// no need for this
+    if (!mounted) return;
+
     if (itemIndex != activeItem) return;
 
     if (minimumDurationFuture != null) await minimumDurationFuture;


### PR DESCRIPTION
### Issues 
- When using the context of a widget in the async method times the screen may be closed before the context has been used in this situation the context will throw an error because it's been removed from the tree 

This issue has no impact on the end-user 
But the fix is very simple we need just to make sure we add a condition checker 
```dart
if(mounted) 
```
before we use the context 


This issue may still exist on other parts of the app that uses async code 