### PR TITLE
766 show video message if announcements mode selected

### DIFF
--- a/lib/src/developer_mode/AnnouncementTest.dart
+++ b/lib/src/developer_mode/AnnouncementTest.dart
@@ -10,12 +10,14 @@ class AnnouncementTest extends StatelessWidget {
   Widget build(BuildContext context) {
     final mosqueManager = context.watch<MosqueManager>();
 
-    if (mosqueManager.activeAnnouncements.isEmpty) {
+    if (mosqueManager.activeAnnouncements(true).isEmpty) {
       return Center(
         child: Text("There are no announcement for this mosque"),
       );
     }
 
-    return AnnouncementScreen();
+    return AnnouncementScreen(
+      enableVideos: !mosqueManager.typeIsMosque,
+    );
   }
 }

--- a/lib/src/pages/home/sub_screens/AnnouncementScreen.dart
+++ b/lib/src/pages/home/sub_screens/AnnouncementScreen.dart
@@ -40,7 +40,8 @@ class _AnnouncementScreenState extends State<AnnouncementScreen> {
   void nextAnnouncement() {
     if (!mounted) return;
 
-    final allAnnouncements = context.read<MosqueManager>().activeAnnouncements(widget.enableVideos);
+    final mosqueManager = context.read<MosqueManager>();
+    final allAnnouncements = mosqueManager.activeAnnouncements(widget.enableVideos);
     index++;
 
     if (index >= allAnnouncements.length) {
@@ -59,7 +60,7 @@ class _AnnouncementScreenState extends State<AnnouncementScreen> {
     } else {
       _controller = YoutubePlayerController(
         initialVideoId: YoutubePlayer.convertUrlToId(activeAnnouncement!.video!)!,
-        flags: YoutubePlayerFlags(autoPlay: true, mute: true),
+        flags: YoutubePlayerFlags(autoPlay: true, mute: mosqueManager.typeIsMosque),
       );
 
       /// if announcement didn't started playing after 20 seconds skip it

--- a/lib/src/pages/home/sub_screens/AnnouncementScreen.dart
+++ b/lib/src/pages/home/sub_screens/AnnouncementScreen.dart
@@ -16,9 +16,16 @@ import '../widgets/SalahTimesBar.dart';
 
 /// show all announcements in one after another
 class AnnouncementScreen extends StatefulWidget {
-  AnnouncementScreen({Key? key, this.onDone}) : super(key: key);
+  AnnouncementScreen({
+    Key? key,
+    this.onDone,
+    this.enableVideos = true,
+  }) : super(key: key);
 
   final VoidCallback? onDone;
+
+  /// used to disable videos on mosques
+  final bool enableVideos;
 
   @override
   State<AnnouncementScreen> createState() => _AnnouncementScreenState();
@@ -31,7 +38,7 @@ class _AnnouncementScreenState extends State<AnnouncementScreen> {
   void nextAnnouncement() {
     if (!mounted) return;
 
-    final allAnnouncements = context.read<MosqueManager>().activeAnnouncements;
+    final allAnnouncements = context.read<MosqueManager>().activeAnnouncements(widget.enableVideos);
     index++;
 
     if (index >= allAnnouncements.length) {
@@ -58,7 +65,7 @@ class _AnnouncementScreenState extends State<AnnouncementScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final announcements = context.read<MosqueManager>().activeAnnouncements;
+    final announcements = context.read<MosqueManager>().activeAnnouncements(widget.enableVideos);
 
     if (announcements.isEmpty) return NormalHomeSubScreen();
 

--- a/lib/src/pages/home/workflow/normal_workflow.dart
+++ b/lib/src/pages/home/workflow/normal_workflow.dart
@@ -13,6 +13,7 @@ import 'package:mawaqit/src/pages/home/sub_screens/takberat_aleid_screen.dart';
 import 'package:mawaqit/src/pages/home/widgets/mosque_background_screen.dart';
 import 'package:mawaqit/src/pages/home/widgets/workflows/repeating_workflow_widget.dart';
 import 'package:mawaqit/src/services/mosque_manager.dart';
+import 'package:mawaqit/src/services/user_preferences_manager.dart';
 import 'package:provider/provider.dart';
 
 const _HadithDuration = Duration(seconds: 90);
@@ -57,6 +58,7 @@ class _NormalWorkflowScreenState extends State<NormalWorkflowScreen> {
   @override
   Widget build(BuildContext context) {
     final mosqueManager = context.watch<MosqueManager>();
+    final userPrefs = context.watch<UserPreferencesManager>();
 
     return RepeatingWorkFlowWidget(
       child: NormalHomeSubScreen(),
@@ -65,7 +67,7 @@ class _NormalWorkflowScreenState extends State<NormalWorkflowScreen> {
         RepeatingWorkflowItem(
           builder: (context, next) => AnnouncementScreen(
             onDone: next,
-            enableVideos: !mosqueManager.typeIsMosque,
+            enableVideos: !mosqueManager.typeIsMosque || userPrefs.isSecondaryScreen,
           ),
           repeatingDuration: _AnnouncementRepeatDuration,
         ),

--- a/lib/src/pages/home/workflow/normal_workflow.dart
+++ b/lib/src/pages/home/workflow/normal_workflow.dart
@@ -63,7 +63,10 @@ class _NormalWorkflowScreenState extends State<NormalWorkflowScreen> {
       items: [
         /// announcement screen
         RepeatingWorkflowItem(
-          builder: (context, next) => AnnouncementScreen(onDone: next),
+          builder: (context, next) => AnnouncementScreen(
+            onDone: next,
+            enableVideos: !mosqueManager.typeIsMosque,
+          ),
           repeatingDuration: _AnnouncementRepeatDuration,
         ),
 

--- a/lib/src/services/mixins/mosque_helpers_mixins.dart
+++ b/lib/src/services/mixins/mosque_helpers_mixins.dart
@@ -327,9 +327,7 @@ mixin MosqueHelpersMixin on ChangeNotifier {
     return false;
   }
 
-  /// remove videos in case of mosque screen
-  /// todo check for primary/secondary screen
-  List<Announcement> get activeAnnouncements {
+  List<Announcement> activeAnnouncements(bool enableVideos) {
     return mosque!.announcements.where((element) {
       final startDate = DateTime.tryParse(element.startDate ?? '');
       final endDate = DateTime.tryParse(element.endDate ?? '');
@@ -340,8 +338,8 @@ mixin MosqueHelpersMixin on ChangeNotifier {
       /// on offline mode we don't show videos
       if (element.video != null && !isOnline) return false;
 
-      /// on mosque screen we don't show videos
-      if (element.video != null && typeIsMosque) return false;
+      /// on mosque screen we don't show videos in certain conditions
+      if (element.video != null && !enableVideos) return false;
 
       return inTime;
     }).toList();


### PR DESCRIPTION
Show video announcements if the user enabled the announcement mode 

Until now the primary/secondary screen has had no effect on the video announcement 
If we should show videos on the secondary screen please let me know so I do it with this pull request 

 