### PR TITLE
allow developer to test staging backend

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -11,6 +11,8 @@
   "tryAgain": "Try Again",
   "closeApp": "Close app",
   "quit": "Quit",
+  "forceStaging": "Force Staging",
+  "disableStaging": "Disable Staging",
   "sureCloseApp": "Are you sure you want to quit the application?",
   "ok": "OK",
   "cancel": "CANCEL",

--- a/lib/src/developer_mode/DrawerListTest.dart
+++ b/lib/src/developer_mode/DrawerListTest.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:mawaqit/i18n/l10n.dart';
 import 'package:mawaqit/src/pages/HomeScreen.dart';
 import 'package:mawaqit/src/pages/developer/DeveloperScreen.dart';
+import 'package:mawaqit/src/services/user_preferences_manager.dart';
 import 'package:provider/provider.dart';
 
 import '../elements/DrawerListTitle.dart';
@@ -23,6 +24,8 @@ class DrawerListDeveloper extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final userPreferencesManager = Provider.of<UserPreferencesManager>(context);
+
     return ListView(
       shrinkWrap: true,
       primary: false,
@@ -126,6 +129,11 @@ class DrawerListDeveloper extends StatelessWidget {
           ),
         ),
 
+        SwitchListTile(
+          value: userPreferencesManager.forceStaging,
+          onChanged: (value) => userPreferencesManager.forceStaging = value,
+          title: Text(S.of(context).forceStaging),
+        ),
         Divider(
           color: Colors.grey,
         ),

--- a/lib/src/elements/RaisedGradientButton.dart
+++ b/lib/src/elements/RaisedGradientButton.dart
@@ -21,7 +21,7 @@ class RaisedGradientButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     double radius = 80;
-    return Container(
+    return Ink(
       width: width,
       height: 50.0,
       decoration: BoxDecoration(
@@ -39,11 +39,10 @@ class RaisedGradientButton extends StatelessWidget {
       child: Material(
         color: Colors.transparent,
         child: InkWell(
+          focusColor: Colors.white.withOpacity(.5),
           autofocus: autoFocus ?? false,
           onTap: onPressed as void Function()?,
-          child: Center(
-            child: child,
-          ),
+          child: Center(child: child),
           borderRadius: BorderRadius.all(
             Radius.circular(radius),
           ),

--- a/lib/src/helpers/Api.dart
+++ b/lib/src/helpers/Api.dart
@@ -4,12 +4,13 @@ import 'package:flutter/material.dart';
 import 'package:mawaqit/src/helpers/ApiInterceptor.dart';
 import 'package:mawaqit/src/models/mosqueConfig.dart';
 import 'package:mawaqit/src/models/times.dart';
+import 'package:pretty_dio_logger/pretty_dio_logger.dart';
 
 import '../models/mosque.dart';
 import '../models/weather.dart';
 
-const kBaseUrlV2 = 'https://mawaqit.net/api/2.0';
-const kBaseUrl = 'https://mawaqit.net/api/3.0';
+const kBaseUrl = 'https://mawaqit.net/api';
+const kStagingUrl = 'https://staging.mawaqit.net/api';
 const kStaticFilesUrl = 'https://mawaqit.net/static';
 const token = 'ad283fb2-844b-40fe-967c-5cb593e9005e';
 
@@ -31,6 +32,15 @@ class Api {
     dio.interceptors.add(ApiCacheInterceptor(cacheStore));
   }
 
+  /// only change the base url
+  /// the local value should be saved using UserPreferences
+  static useStagingApi([bool staging = true]) {
+    if (staging)
+      dio.options.baseUrl = kStagingUrl;
+    else
+      dio.options.baseUrl = kBaseUrl;
+  }
+
   static Future<bool> kMosqueExistence(int id) {
     var url = 'https://mawaqit.net/en/id/$id?view=desktop';
 
@@ -40,11 +50,7 @@ class Api {
   static Future<bool> checkTheInternetConnection() {
     final url = 'https://www.google.com/';
 
-    return dio
-        .get(url)
-        .timeout(Duration(seconds: 5))
-        .then((value) => true)
-        .catchError((e) => false);
+    return dio.get(url).timeout(Duration(seconds: 5)).then((value) => true).catchError((e) => false);
   }
 
   /// re check the mosque if there are any updated data
@@ -56,7 +62,7 @@ class Api {
   }
 
   static Future<Mosque> getMosque(String id) async {
-    final response = await dio.get('/mosque/$id/info');
+    final response = await dio.get('/3.0/mosque/$id/info');
 
     return Mosque.fromMap(response.data);
   }
@@ -70,7 +76,7 @@ class Api {
   }
 
   static Future<MosqueConfig> getMosqueConfig(String id) async {
-    final response = await dio.get('/mosque/$id/config');
+    final response = await dio.get('/3.0/mosque/$id/config');
 
     return MosqueConfig.fromMap(response.data);
   }
@@ -84,20 +90,20 @@ class Api {
   }
 
   static Future<Times> getMosqueTimes(String id) async {
-    final response = await dio.get('/mosque/$id/times');
+    final response = await dio.get('/3.0/mosque/$id/times');
 
     return Times.fromMap(response.data);
   }
 
   static Future<Mosque> searchMosqueWithId(String mosqueId) async {
-    final response = await dio.get('/mosque/$mosqueId');
+    final response = await dio.get('/3.0/mosque/$mosqueId');
 
     return Mosque.fromMap(response.data);
   }
 
   static Future<List<Mosque>> searchMosques(String mosque, {page = 1}) async {
     final response = await dio.get(
-      '$kBaseUrlV2/mosque/search?word=$mosque&page=$page',
+      '/2.0/mosque/search?word=$mosque&page=$page',
     );
 
     List<Mosque> mosques = [];
@@ -115,7 +121,7 @@ class Api {
 
   static Future<String> randomHadith({String language = 'ar'}) async {
     final response = await dio.get(
-      '$kBaseUrlV2/hadith/random',
+      '/v2.0/hadith/random',
       queryParameters: {'lang': language},
     );
 
@@ -123,7 +129,7 @@ class Api {
   }
 
   static Future<dynamic> getWeather(String mosqueUUID) async {
-    final response = await dio.get('$kBaseUrlV2/mosque/$mosqueUUID/weather');
+    final response = await dio.get('v2.0/mosque/$mosqueUUID/weather');
 
     return Weather.fromMap(response.data);
   }

--- a/lib/src/pages/ErrorScreen.dart
+++ b/lib/src/pages/ErrorScreen.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:mawaqit/src/elements/RaisedGradientButton.dart';
+import 'package:mawaqit/src/helpers/AppRouter.dart';
 import 'package:mawaqit/src/helpers/HexColor.dart';
+import 'package:mawaqit/src/services/user_preferences_manager.dart';
 import 'package:mawaqit/src/widgets/InfoWidget.dart';
+import 'package:provider/provider.dart';
 
 import '../../i18n/l10n.dart';
 
@@ -14,6 +17,7 @@ class ErrorScreen extends StatelessWidget {
     required this.image,
     this.onTryAgain,
     this.tryAgainText,
+    this.allowDisableStaging = true,
   }) : super(key: key);
 
   final String title;
@@ -21,9 +25,12 @@ class ErrorScreen extends StatelessWidget {
   final String image;
   final VoidCallback? onTryAgain;
   final String? tryAgainText;
+  final bool allowDisableStaging;
 
   @override
   Widget build(BuildContext context) {
+    final userPrefs = Provider.of<UserPreferencesManager>(context);
+
     return Scaffold(
       body: SizedBox(
         width: double.infinity,
@@ -49,10 +56,7 @@ class ErrorScreen extends StatelessWidget {
             SizedBox(height: 10),
             Text(
               title,
-              style: TextStyle(
-                  color: Colors.white70,
-                  fontSize: 40.0,
-                  fontWeight: FontWeight.bold),
+              style: TextStyle(color: Colors.white70, fontSize: 40.0, fontWeight: FontWeight.bold),
             ),
             Text(
               description,
@@ -63,17 +67,27 @@ class ErrorScreen extends StatelessWidget {
               autoFocus: true,
               child: Text(
                 tryAgainText ?? S.of(context).tryAgain,
-                style: TextStyle(
-                  color: Colors.white,
-                  fontSize: 18.0,
-                  fontWeight: FontWeight.bold,
-                ),
+                style: TextStyle(color: Colors.white, fontSize: 18.0, fontWeight: FontWeight.bold),
               ),
               width: 250,
-              gradient: LinearGradient(
-                  colors: <Color>[HexColor("#391e61"), HexColor("#490094")]),
+              gradient: LinearGradient(colors: <Color>[HexColor("#391e61"), HexColor("#490094")]),
               onPressed: onTryAgain,
             ),
+            SizedBox(height: 10),
+            if (allowDisableStaging && userPrefs.forceStaging)
+              RaisedGradientButton(
+                autoFocus: true,
+                child: Text(
+                  tryAgainText ?? S.of(context).disableStaging,
+                  style: TextStyle(color: Colors.white, fontSize: 18.0, fontWeight: FontWeight.bold),
+                ),
+                width: 250,
+                gradient: LinearGradient(colors: <Color>[HexColor("#391e61"), HexColor("#490094")]),
+                onPressed: () {
+                  userPrefs.forceStaging = false;
+                  onTryAgain?.call();
+                },
+              ),
             Spacer(),
             Opacity(child: VersionWidget(), opacity: .3),
             SizedBox(height: 10),

--- a/lib/src/pages/SplashScreen.dart
+++ b/lib/src/pages/SplashScreen.dart
@@ -11,6 +11,7 @@ import 'package:hive_flutter/adapters.dart';
 import 'package:mawaqit/const/resource.dart';
 import 'package:mawaqit/i18n/AppLanguage.dart';
 import 'package:mawaqit/i18n/l10n.dart';
+import 'package:mawaqit/main.dart';
 import 'package:mawaqit/src/helpers/AppRouter.dart';
 
 import 'package:mawaqit/src/helpers/HttpOverrides.dart';

--- a/lib/src/pages/mosque_search/widgets/MosqueInputId.dart
+++ b/lib/src/pages/mosque_search/widgets/MosqueInputId.dart
@@ -1,8 +1,10 @@
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:mawaqit/i18n/l10n.dart';
+import 'package:mawaqit/main.dart';
 import 'package:mawaqit/src/models/mosque.dart';
 import 'package:mawaqit/src/services/mosque_manager.dart';
 import 'package:mawaqit/src/widgets/mosque_simple_tile.dart';
@@ -43,7 +45,7 @@ class _MosqueInputIdState extends State<MosqueInputId> {
         searchOutput = value;
         loading = false;
       });
-    }).catchError((e) {
+    }).catchError((e, stack) {
       if (e is InvalidMosqueId) {
         setState(() {
           loading = false;
@@ -73,9 +75,7 @@ class _MosqueInputIdState extends State<MosqueInputId> {
               style: TextStyle(
                 fontSize: 25.0,
                 fontWeight: FontWeight.w700,
-                color: theme.brightness == Brightness.dark
-                    ? null
-                    : theme.primaryColor,
+                color: theme.brightness == Brightness.dark ? null : theme.primaryColor,
               ),
             ),
             SizedBox(height: 10),
@@ -86,10 +86,7 @@ class _MosqueInputIdState extends State<MosqueInputId> {
                 autoFocus: true,
                 mosque: searchOutput!,
                 onTap: () {
-                  context
-                      .read<MosqueManager>()
-                      .setMosqueUUid(searchOutput!.uuid.toString())
-                      .then((value) {
+                  context.read<MosqueManager>().setMosqueUUid(searchOutput!.uuid.toString()).then((value) {
                     widget.onDone?.call();
                   }).catchError((e) {
                     if (e is InvalidMosqueId) {
@@ -120,12 +117,10 @@ class _MosqueInputIdState extends State<MosqueInputId> {
         child: TextFormField(
           controller: inputController,
           style: GoogleFonts.inter(
-            color:
-                theme.brightness == Brightness.dark ? null : theme.primaryColor,
+            color: theme.brightness == Brightness.dark ? null : theme.primaryColor,
           ),
           onFieldSubmitted: _setMosqueId,
-          cursorColor:
-              theme.brightness == Brightness.dark ? null : theme.primaryColor,
+          cursorColor: theme.brightness == Brightness.dark ? null : theme.primaryColor,
           keyboardType: TextInputType.number,
           autofocus: true,
           textInputAction: TextInputAction.search,
@@ -139,16 +134,12 @@ class _MosqueInputIdState extends State<MosqueInputId> {
             hintText: S.of(context).selectWithMosqueId,
             hintStyle: TextStyle(
               fontWeight: FontWeight.normal,
-              color: theme.brightness == Brightness.dark
-                  ? null
-                  : theme.primaryColor.withOpacity(0.4),
+              color: theme.brightness == Brightness.dark ? null : theme.primaryColor.withOpacity(0.4),
             ),
             suffixIcon: IconButton(
               tooltip: "Search by Id",
               icon: loading ? CircularProgressIndicator() : Icon(Icons.search),
-              color: theme.brightness == Brightness.dark
-                  ? Colors.white70
-                  : theme.primaryColor,
+              color: theme.brightness == Brightness.dark ? Colors.white70 : theme.primaryColor,
               onPressed: () => _setMosqueId(inputController.text),
             ),
             focusedBorder: OutlineInputBorder(

--- a/lib/src/services/user_preferences_manager.dart
+++ b/lib/src/services/user_preferences_manager.dart
@@ -1,4 +1,6 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:mawaqit/src/helpers/Api.dart';
 
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -6,11 +8,18 @@ const _announcementsStoreKey = 'UserPreferencesManager.AnnouncementsOnly';
 const _developerModeKey = 'UserPreferencesManager.developer.mode.enabled';
 const _secondaryScreenKey = 'UserPreferencesManager.secondary.screen.enabled';
 const _webViewModeKey = 'UserPreferencesManager.webView.mode.enabled';
+const _forceStagingKey = 'UserPreferencesManager.api.settings.staging';
 
 /// this manager responsible for managing user preferences
 class UserPreferencesManager extends ChangeNotifier {
   UserPreferencesManager() {
-    SharedPreferences.getInstance().then((value) => _sharedPref = value);
+    _init();
+  }
+
+  Future<void> _init() async {
+    _sharedPref = await SharedPreferences.getInstance();
+
+    Api.useStagingApi(forceStaging);
   }
 
   late SharedPreferences _sharedPref;
@@ -40,6 +49,17 @@ class UserPreferencesManager extends ChangeNotifier {
 
   set webViewMode(bool value) {
     _sharedPref.setBool(_webViewModeKey, value);
+    notifyListeners();
+  }
+
+  bool get forceStaging => _sharedPref.getBool(_forceStagingKey) ?? false;
+
+  /// this method is used to force staging api
+  /// if value is null, it will be [false]
+  set forceStaging(bool value) {
+    Api.useStagingApi(value);
+
+    _sharedPref.setBool(_forceStagingKey, value);
     notifyListeners();
   }
 }


### PR DESCRIPTION
### Requested feature 
Allow backend developers to test their staging API in the application from the developer menu 

### Logic
1. Added switch tile at the end of the developer options to enable/disable the staging backend subdomain 
2. by default the app will use the production API even in development 
3. User will have the ability to disable the staging mode from error screens so he won't be locked out from using the app 
4. Disable staging button will only appear if staging mode is enabled 