### PR TITLE
Move API access token into env variables

### DIFF
--- a/lib/src/helpers/Api.dart
+++ b/lib/src/helpers/Api.dart
@@ -11,7 +11,7 @@ import '../models/weather.dart';
 const kBaseUrl = 'https://mawaqit.net/api';
 const kStagingUrl = 'https://staging.mawaqit.net/api';
 const kStaticFilesUrl = 'https://mawaqit.net/static';
-const token = 'ad283fb2-844b-40fe-967c-5cb593e9005e';
+const token = String.fromEnvironment('mawaqit.api.key');
 
 class Api {
   static final dio = Dio(


### PR DESCRIPTION
API access token moved into dart variables. Each developer no will be required to ask our backend for token 
then he can use it by runner --dart-define=mawaqit.api.key={{key}} or by edit the configuration of the IDE 

![image](https://user-images.githubusercontent.com/63953869/236672422-58b21efa-f85e-47c8-a928-075852f612bf.png)


The full running command is 
 
 `flutter run --flavor=noLeanback --dart-define=mawaqit.api.key={{key}}`