### PR TITLE
add loading spinner in the mosque selector tile

### DIFF
--- a/lib/src/pages/mosque_search/widgets/MosqueInputId.dart
+++ b/lib/src/pages/mosque_search/widgets/MosqueInputId.dart
@@ -86,7 +86,7 @@ class _MosqueInputIdState extends State<MosqueInputId> {
                 autoFocus: true,
                 mosque: searchOutput!,
                 onTap: () {
-                  context.read<MosqueManager>().setMosqueUUid(searchOutput!.uuid.toString()).then((value) {
+                  return context.read<MosqueManager>().setMosqueUUid(searchOutput!.uuid.toString()).then((value) {
                     widget.onDone?.call();
                   }).catchError((e) {
                     if (e is InvalidMosqueId) {

--- a/lib/src/pages/mosque_search/widgets/MosqueInputSearch.dart
+++ b/lib/src/pages/mosque_search/widgets/MosqueInputSearch.dart
@@ -71,11 +71,8 @@ class _MosqueInputSearchState extends State<MosqueInputSearch> {
   }
 
   /// handle on mosque tile clicked
-  void _selectMosque(Mosque mosque) {
-    context
-        .read<MosqueManager>()
-        .setMosqueUUid(mosque.uuid.toString())
-        .then((value) {
+  Future<void> _selectMosque(Mosque mosque) {
+    return context.read<MosqueManager>().setMosqueUUid(mosque.uuid.toString()).then((value) {
       widget.onDone?.call();
     }).catchError((e) {
       if (e is InvalidMosqueId) {
@@ -113,16 +110,11 @@ class _MosqueInputSearchState extends State<MosqueInputSearch> {
                 style: TextStyle(
                   fontSize: 25.0,
                   fontWeight: FontWeight.w700,
-                  color: theme.brightness == Brightness.dark
-                      ? null
-                      : theme.primaryColor,
+                  color: theme.brightness == Brightness.dark ? null : theme.primaryColor,
                 ),
               ).animate().slideY(begin: -1).fade(),
               SizedBox(height: 20),
-              searchField(theme)
-                  .animate()
-                  .slideX(begin: 1, delay: 200.milliseconds)
-                  .fadeIn(),
+              searchField(theme).animate().slideX(begin: 1, delay: 200.milliseconds).fadeIn(),
               SizedBox(height: 20),
               for (var i = 0; i < results.length; i++)
                 MosqueSimpleTile(
@@ -146,8 +138,7 @@ class _MosqueInputSearchState extends State<MosqueInputSearch> {
                       builder: (context) {
                         if (loading) return CircularProgressIndicator();
 
-                        if (noMore && results.isEmpty)
-                          return Text(S.of(context).mosqueNoResults);
+                        if (noMore && results.isEmpty) return Text(S.of(context).mosqueNoResults);
                         if (noMore) return Text(S.of(context).mosqueNoMore);
 
                         return SizedBox();
@@ -170,8 +161,7 @@ class _MosqueInputSearchState extends State<MosqueInputSearch> {
         color: theme.brightness == Brightness.dark ? null : theme.primaryColor,
       ),
       onFieldSubmitted: (val) => _searchMosque(val, 1),
-      cursorColor:
-          theme.brightness == Brightness.dark ? null : theme.primaryColor,
+      cursorColor: theme.brightness == Brightness.dark ? null : theme.primaryColor,
       autofocus: true,
       textInputAction: TextInputAction.search,
       decoration: InputDecoration(
@@ -181,9 +171,7 @@ class _MosqueInputSearchState extends State<MosqueInputSearch> {
         hintText: S.of(context).searchForMosque,
         hintStyle: TextStyle(
           fontWeight: FontWeight.normal,
-          color: theme.brightness == Brightness.dark
-              ? null
-              : theme.primaryColor.withOpacity(0.4),
+          color: theme.brightness == Brightness.dark ? null : theme.primaryColor.withOpacity(0.4),
         ),
         suffixIcon: InkWell(
           borderRadius: BorderRadius.circular(30),


### PR DESCRIPTION
# Issues

after adding the precaching for images, and voices this mosque selector tile become irresponsive. for better UX app should give the user instant feedback that he take his order. 

# Solution

for instant feedback, I added a spinner in the mosque tile user tapped on. so once he tap on the time the spinner will start. 