### PR TITLE
disable caching for non wanted api, weather, checkConnection

### DIFF
--- a/lib/src/helpers/Api.dart
+++ b/lib/src/helpers/Api.dart
@@ -9,7 +9,6 @@ import 'package:mawaqit/src/models/times.dart';
 import '../models/mosque.dart';
 import '../models/weather.dart';
 
-
 class Api {
   static final dio = Dio(
     BaseOptions(
@@ -46,7 +45,11 @@ class Api {
   static Future<bool> checkTheInternetConnection() {
     final url = 'https://www.google.com/';
 
-    return dio.get(url).timeout(Duration(seconds: 5)).then((value) => true).catchError((e) => false);
+    return dio
+        .get(url, options: Options(extra: {'disableCache': true}))
+        .timeout(Duration(seconds: 5))
+        .then((value) => true)
+        .catchError((e) => false);
   }
 
   /// re check the mosque if there are any updated data
@@ -125,7 +128,10 @@ class Api {
   }
 
   static Future<dynamic> getWeather(String mosqueUUID) async {
-    final response = await dio.get('/2.0/mosque/$mosqueUUID/weather');
+    final response = await dio.get(
+      '/2.0/mosque/$mosqueUUID/weather',
+      options: Options(extra: {'disableCache': true}),
+    );
 
     return Weather.fromMap(response.data);
   }

--- a/lib/src/helpers/ApiInterceptor.dart
+++ b/lib/src/helpers/ApiInterceptor.dart
@@ -5,11 +5,9 @@ import 'package:dio_cache_interceptor/dio_cache_interceptor.dart';
 class ApiCacheInterceptor extends DioCacheInterceptor {
   final CacheStore store;
 
-  ApiCacheInterceptor(this.store)
-      : super(options: CacheOptions(store: store, policy: CachePolicy.refresh));
+  ApiCacheInterceptor(this.store) : super(options: CacheOptions(store: store, policy: CachePolicy.refresh));
 
-  String getCacheKey(RequestOptions options) =>
-      CacheOptions.defaultCacheKeyBuilder(options);
+  String getCacheKey(RequestOptions options) => CacheOptions.defaultCacheKeyBuilder(options);
 
   @override
   Future<void> onRequest(
@@ -17,7 +15,7 @@ class ApiCacheInterceptor extends DioCacheInterceptor {
     RequestInterceptorHandler handler,
   ) async {
     await store.get(getCacheKey(options)).then((value) {
-      if (value != null) {
+      if (value != null && options.extra['disableCache'] != true) {
         options.headers['If-Modified-Since'] = value.lastModified;
       }
     });
@@ -32,7 +30,7 @@ class ApiCacheInterceptor extends DioCacheInterceptor {
 
     final value = await store.get(getCacheKey(err.requestOptions));
 
-    if (value != null)
+    if (value != null && err.requestOptions.extra['disableCache'] != true)
       return handler.resolve(value.toResponse(err.requestOptions));
 
     return handler.next(err);


### PR DESCRIPTION
# Issue
1. app caching interceptor was using the cached value of the google.com website 

# Resolve 
- disable the cache for the non-disered to be cached API endpoint like 
  - Weather API 
  - google.com (check connection API)