### PR TITLE
custom month names on TN, DZ

### DIFF
--- a/lib/src/helpers/DateUtils.dart
+++ b/lib/src/helpers/DateUtils.dart
@@ -1,7 +1,7 @@
 import 'package:intl/intl.dart';
 import 'package:mawaqit/src/helpers/StringUtils.dart';
 
-const tunisMonthNames = [
+const _maghrebMonthNames = [
   'جانفي',
   'فيفري',
   'مارس',
@@ -16,14 +16,19 @@ const tunisMonthNames = [
   'ديسمبر'
 ];
 
+const _maghrebMonthsLocales = [
+  'AR_TN',
+  'AR_DZ',
+];
+
 extension MawaqitDateUtils on DateTime {
   String formatIntoMawaqitFormat({String local = 'en'}) {
     var formatter = local == 'ar' || local == 'fr'
         ? DateFormat('EEEE, dd MMMM, yyyy', local)
         : DateFormat('EEEE, MMMM dd, yyyy', local);
 
-    if (local.toUpperCase() == 'AR_TN' || local.toUpperCase() == 'DZ') {
-      formatter.dateSymbols.MONTHS = tunisMonthNames;
+    if (_maghrebMonthsLocales.contains(local.toUpperCase())) {
+      formatter.dateSymbols.MONTHS = _maghrebMonthNames;
     }
 
     formatter.useNativeDigits = false;

--- a/lib/src/helpers/DateUtils.dart
+++ b/lib/src/helpers/DateUtils.dart
@@ -1,13 +1,31 @@
 import 'package:intl/intl.dart';
 import 'package:mawaqit/src/helpers/StringUtils.dart';
 
+const tunisMonthNames = [
+  'جانفي',
+  'فيفري',
+  'مارس',
+  'أفريل',
+  'ماي',
+  'جوان',
+  'جويلية',
+  'أوت',
+  'سبتمبر',
+  'أكتوبر',
+  'نوفمبر',
+  'ديسمبر'
+];
+
 extension MawaqitDateUtils on DateTime {
-  String formatIntoMawaqitFormat({
-    String local = 'en',
-  }) {
+  String formatIntoMawaqitFormat({String local = 'en'}) {
     var formatter = local == 'ar' || local == 'fr'
-        ? DateFormat('EEEE, dd MMMM, yyyy' , local)
-        : DateFormat('EEEE, MMMM dd, yyyy' , local);
+        ? DateFormat('EEEE, dd MMMM, yyyy', local)
+        : DateFormat('EEEE, MMMM dd, yyyy', local);
+
+    if (local.toUpperCase() == 'AR_TN' || local.toUpperCase() == 'DZ') {
+      formatter.dateSymbols.MONTHS = tunisMonthNames;
+    }
+
     formatter.useNativeDigits = false;
     return formatter.format(this).capitalizeFirstOfEach();
   }

--- a/lib/src/pages/home/widgets/HomeDateWidget.dart
+++ b/lib/src/pages/home/widgets/HomeDateWidget.dart
@@ -18,6 +18,9 @@ class HomeDateWidget extends StatelessWidget {
     final lang = Localizations.localeOf(context).languageCode;
 
     var hijriDate = mosqueManager.mosqueHijriDate();
+    var hijriDateFormatted = hijriDate.formatMawaqitType();
+
+    final georgianDate = now.formatIntoMawaqitFormat(local: '${lang}_${mosqueManager.mosque?.countryCode}');
 
     return FittedBox(
       fit: BoxFit.scaleDown,
@@ -30,14 +33,12 @@ class HomeDateWidget extends StatelessWidget {
           duration: Duration(seconds: 10),
           disableSecond: mosqueManager.mosqueConfig!.hijriDateEnabled == false,
           first: Text(
-            now.formatIntoMawaqitFormat(local: lang),
+            georgianDate,
             style: TextStyle(
               color: Colors.white,
               fontSize: 2.7.vw,
               shadows: kHomeTextShadow,
-              fontFamily: StringManager.getFontFamilyByString(
-                now.formatIntoMawaqitFormat(local: lang),
-              ),
+              fontFamily: StringManager.getFontFamilyByString(georgianDate),
               height: .8,
             ),
           ),
@@ -46,18 +47,14 @@ class HomeDateWidget extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
               Text(
-                hijriDate.formatMawaqitType(),
-                textDirection: hijriDate.formatMawaqitType().isArabic()
-                    ? TextDirection.rtl
-                    : TextDirection.ltr,
+                hijriDateFormatted,
+                textDirection: hijriDateFormatted.isArabic() ? TextDirection.rtl : TextDirection.ltr,
                 style: TextStyle(
                   color: Colors.white,
                   fontSize: 2.5.vw,
                   height: .8,
                   shadows: kHomeTextShadow,
-                  fontFamily: StringManager.getFontFamilyByString(
-                    hijriDate.formatMawaqitType(),
-                  ),
+                  fontFamily: StringManager.getFontFamilyByString(hijriDateFormatted),
                 ),
               ),
               if (hijriDate.isInLunarDays)


### PR DESCRIPTION
Replace the default month names in Algeria and Tunis to 


- جانفي
- فيفري
- مارس
- أفريل
- ماي
- جوان
- جويلية
- أوت
- سبتمبر
- أكتوبر
- نوفمبر
- ديسمبر
