### PR TITLE
835 170 feedbacks

### DIFF
--- a/lib/src/helpers/StringUtils.dart
+++ b/lib/src/helpers/StringUtils.dart
@@ -33,36 +33,24 @@ class StringManager {
   static const fontFamilyArial = "arial";
   static const fontFamilyHelvetica = "helvetica";
 
-  static const rtlLanguages = const [
-    'ar',
-    'he',
-    'fa',
-    'ur',
-    'arc',
-    'az',
-    'dv',
-    'ckb'
-  ];
+  static const rtlLanguages = const ['ar', 'he', 'fa', 'ur', 'arc', 'az', 'dv', 'ckb'];
 
   static TextDirection getTextDirectionOfLocal(Locale locale) {
-    return rtlLanguages.contains(locale.languageCode)
-        ? TextDirection.rtl
-        : TextDirection.ltr;
+    return rtlLanguages.contains(locale.languageCode) ? TextDirection.rtl : TextDirection.ltr;
   }
 
 ///////////// Salah count down text in Time widget
-  static String getCountDownText(
-      BuildContext context, Duration salahTime, String salahName) {
+  static String getCountDownText(BuildContext context, Duration salahTime, String salahName) {
     return [
       "$salahName ${S.of(context).in1} ",
       if (salahTime.inMinutes > 0)
         "${salahTime.inHours.toString().padLeft(2, '0')}:${(salahTime.inMinutes % 60).toString().padLeft(2, '0')}",
-      if (salahTime.inMinutes == 0)
-        "${(salahTime.inSeconds % 60).toString().padLeft(2, '0')} ${S.of(context).sec}",
+      if (salahTime.inMinutes == 0) "${(salahTime.inSeconds % 60).toString().padLeft(2, '0')} ${S.of(context).sec}",
     ].join();
   }
 
 //////////// get font family
+  @deprecated
   static String? getFontFamilyByString(String value) {
     if (value.isArabic() || value.isUrdu()) {
       return fontFamilyKufi;
@@ -70,8 +58,7 @@ class StringManager {
     return null;
   }
 
-  @Deprecated(
-      'user [StringManager.getFontFamilyByString] or anyString.isArabic')
+  @Deprecated('user [StringManager.getFontFamilyByString] or anyString.isArabic')
   static String? getFontFamily(BuildContext context) {
     String langCode = "${context.read<AppLanguage>().appLocal}";
     if (langCode == "ar" || langCode == "ur") {
@@ -81,19 +68,15 @@ class StringManager {
   }
 
   /// return list
+  @deprecated
   static List convertStringToList(String text) {
     List<String> list = List.from(text.split(RegExp(r"\s+")));
 
     List<int> arabicIndexes = [];
-    arabicIndexes = list
-        .asMap()
-        .entries
-        .where((entry) => arabicLetters.hasMatch(entry.value))
-        .map((entry) => entry.key)
-        .toList();
+    arabicIndexes =
+        list.asMap().entries.where((entry) => arabicLetters.hasMatch(entry.value)).map((entry) => entry.key).toList();
     if (arabicIndexes.isEmpty) return list;
-    List<String> sublist =
-        list.sublist(arabicIndexes.first, arabicIndexes.last + 1);
+    List<String> sublist = list.sublist(arabicIndexes.first, arabicIndexes.last + 1);
 // Reverse the sublist
     sublist = sublist.reversed.toList();
 // Replace the original sublist with the reversed sublist

--- a/lib/src/pages/home/sub_screens/AdhanSubScreen.dart
+++ b/lib/src/pages/home/sub_screens/AdhanSubScreen.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:mawaqit/i18n/l10n.dart';
 import 'package:mawaqit/src/helpers/RelativeSizes.dart';
-import 'package:mawaqit/src/helpers/StringUtils.dart';
 import 'package:mawaqit/src/helpers/mawaqit_icons_icons.dart';
 import 'package:mawaqit/src/helpers/repaint_boundaries.dart';
 import 'package:mawaqit/src/pages/home/widgets/FlashAnimation.dart';
@@ -94,7 +93,6 @@ class _AdhanSubScreenState extends State<AdhanSubScreen> {
                         style: TextStyle(
                           fontWeight: FontWeight.bold,
                           fontSize: 15.vw,
-                          fontFamily: StringManager.getFontFamilyByString(S.of(context).alAdhan),
                           height: .001,
                           color: Colors.white,
                           shadows: kHomeTextShadow,

--- a/lib/src/pages/home/sub_screens/AnnouncementScreen.dart
+++ b/lib/src/pages/home/sub_screens/AnnouncementScreen.dart
@@ -12,7 +12,6 @@ import 'package:mawaqit/src/services/mosque_manager.dart';
 import 'package:provider/provider.dart';
 import 'package:youtube_player_flutter/youtube_player_flutter.dart';
 
-import '../../../helpers/StringUtils.dart';
 import '../widgets/salah_items/responsive_mini_salah_bar_widget.dart';
 
 /// show all announcements in one after another
@@ -107,7 +106,6 @@ class _TextAnnouncement extends StatelessWidget {
               shadows: kAnnouncementTextShadow,
               fontSize: 50,
               fontWeight: FontWeight.bold,
-              fontFamily: StringManager.getFontFamilyByString(title ?? ''),
               color: Colors.amber,
               letterSpacing: 1,
             ),
@@ -123,7 +121,6 @@ class _TextAnnouncement extends StatelessWidget {
                 shadows: kAnnouncementTextShadow,
                 fontSize: 8.vwr,
                 fontWeight: FontWeight.bold,
-                fontFamily: StringManager.getFontFamilyByString(content),
                 color: Colors.white,
                 letterSpacing: 1,
               ),

--- a/lib/src/pages/home/sub_screens/IqamaSubScreen.dart
+++ b/lib/src/pages/home/sub_screens/IqamaSubScreen.dart
@@ -4,7 +4,6 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:mawaqit/const/resource.dart';
 import 'package:mawaqit/i18n/l10n.dart';
 import 'package:mawaqit/src/helpers/RelativeSizes.dart';
-import 'package:mawaqit/src/helpers/StringUtils.dart';
 import 'package:mawaqit/src/helpers/repaint_boundaries.dart';
 import 'package:mawaqit/src/pages/home/widgets/FlashAnimation.dart';
 import 'package:mawaqit/src/services/audio_manager.dart';
@@ -57,7 +56,6 @@ class _IqamaSubScreenState extends State<IqamaSubScreen> {
               color: Colors.white,
               fontWeight: FontWeight.w700,
               shadows: kAfterAdhanTextShadow,
-              fontFamily: StringManager.getFontFamilyByString(tr.alIqama),
             ),
             textAlign: TextAlign.center,
           ).animate().slide(begin: Offset(0, -1)).fade().addRepaintBoundary(),
@@ -80,7 +78,6 @@ class _IqamaSubScreenState extends State<IqamaSubScreen> {
               fontWeight: FontWeight.bold,
               fontSize: 4.vwr,
               color: Colors.white,
-              fontFamily: StringManager.getFontFamilyByString(tr.turnOfPhones),
               shadows: kAfterAdhanTextShadow,
             ),
           ).animate().slide(begin: Offset(0, 1)).fade().addRepaintBoundary(),

--- a/lib/src/pages/home/sub_screens/IqamaaCountDownSubScreen.dart
+++ b/lib/src/pages/home/sub_screens/IqamaaCountDownSubScreen.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:mawaqit/i18n/l10n.dart';
 import 'package:mawaqit/src/helpers/RelativeSizes.dart';
-import 'package:mawaqit/src/helpers/StringUtils.dart';
 import 'package:mawaqit/src/helpers/repaint_boundaries.dart';
 import 'package:mawaqit/src/pages/home/sub_screens/normal_home.dart';
 import 'package:mawaqit/src/pages/home/widgets/WeatherWidget.dart';
@@ -80,12 +79,12 @@ class _IqamaaCountDownSubScreenState extends State<IqamaaCountDownSubScreen> {
         Text(
           tr.iqamaIn,
           style: TextStyle(
-              fontSize: 7.vwr,
-              color: Colors.white,
-              fontWeight: FontWeight.bold,
-              shadows: kIqamaCountDownTextShadow,
-              height: 1,
-              fontFamily: StringManager.getFontFamilyByString(tr.iqamaIn)),
+            fontSize: 7.vwr,
+            color: Colors.white,
+            fontWeight: FontWeight.bold,
+            shadows: kIqamaCountDownTextShadow,
+            height: 1,
+          ),
         ).animate().slide(delay: .5.seconds).fade().addRepaintBoundary(),
         StreamBuilder(
             stream: Stream.periodic(Duration(seconds: 1)),

--- a/lib/src/pages/home/sub_screens/fajr_wake_up_screen.dart
+++ b/lib/src/pages/home/sub_screens/fajr_wake_up_screen.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:mawaqit/i18n/l10n.dart';
 import 'package:mawaqit/src/helpers/RelativeSizes.dart';
-import 'package:mawaqit/src/helpers/StringUtils.dart';
 import 'package:mawaqit/src/helpers/mawaqit_icons_icons.dart';
 import 'package:mawaqit/src/helpers/repaint_boundaries.dart';
 import 'package:mawaqit/src/pages/home/widgets/FlashAnimation.dart';
@@ -72,7 +71,6 @@ class _FajrWakeUpSubScreenState extends State<FajrWakeUpSubScreen> {
                             style: TextStyle(
                               fontWeight: FontWeight.bold,
                               fontSize: 14.vw,
-                              fontFamily: StringManager.getFontFamilyByString(S.of(context).alAdhan),
                               // height: 2,
                               color: Colors.white,
                               shadows: kHomeTextShadow,

--- a/lib/src/pages/home/sub_screens/normal_home.dart
+++ b/lib/src/pages/home/sub_screens/normal_home.dart
@@ -90,6 +90,7 @@ class NormalHomeSubScreen extends StatelessOrientationWidget {
               Container(
                 color: Colors.black26,
                 height: 5.vh,
+                alignment: Alignment.center,
                 child: FlashWidget(),
               ),
             Footer(hideMessage: true),

--- a/lib/src/pages/home/sub_screens/normal_home.dart
+++ b/lib/src/pages/home/sub_screens/normal_home.dart
@@ -28,10 +28,7 @@ class NormalHomeSubScreen extends StatelessOrientationWidget {
     return Column(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: MosqueHeader(mosque: mosque),
-        ),
+        Directionality(textDirection: TextDirection.ltr, child: MosqueHeader(mosque: mosque)),
         Padding(
           padding: EdgeInsets.symmetric(horizontal: 3.vw).copyWith(top: 1.5.vw),
           child: Row(
@@ -62,10 +59,7 @@ class NormalHomeSubScreen extends StatelessOrientationWidget {
 
     return Column(
       children: [
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: MosqueHeader(mosque: mosque),
-        ),
+        Directionality(textDirection: TextDirection.ltr, child: MosqueHeader(mosque: mosque)),
         Spacer(flex: 2),
         HomeTimeWidget().animate().slideY(delay: Duration(milliseconds: 500)).fadeIn().addRepaintBoundary(),
         Column(

--- a/lib/src/pages/home/widgets/AboveSalahBar.dart
+++ b/lib/src/pages/home/widgets/AboveSalahBar.dart
@@ -7,7 +7,6 @@ import 'package:mawaqit/src/themes/UIShadows.dart';
 import 'package:provider/provider.dart';
 
 import '../../../../i18n/l10n.dart';
-import '../../../helpers/StringUtils.dart';
 import '../../../widgets/TimePeriodWidget.dart';
 
 class AboveSalahBar extends StatelessWidget {
@@ -56,7 +55,6 @@ class AboveSalahBar extends StatelessWidget {
                           color: Colors.white,
                           shadows: kHomeTextShadow,
                           fontSize: isArabic ? 5.3.vr : 6.vr,
-                          fontFamily: StringManager.getFontFamilyByString(countDownText),
                         ),
                   ),
                 ),

--- a/lib/src/pages/home/widgets/FlashWidget.dart
+++ b/lib/src/pages/home/widgets/FlashWidget.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:marquee/marquee.dart';
 import 'package:mawaqit/src/helpers/RelativeSizes.dart';
 import 'package:mawaqit/src/helpers/StringUtils.dart';
 import 'package:provider/provider.dart';
+import 'package:text_scroll/text_scroll.dart';
 
 import '../../../helpers/HexColor.dart';
 import '../../../services/mosque_manager.dart';
@@ -28,15 +28,14 @@ class FlashWidget extends StatelessWidget {
         //todo get the message
         ? SizedBox()
         : RepaintBoundary(
-            child: Directionality(
-              textDirection: mosque.flash?.orientation == 'rtl' ? TextDirection.rtl : TextDirection.ltr,
-              child: Marquee(
-                velocity: 90,
-                decelerationCurve: Curves.linear,
-                accelerationCurve: Curves.linear,
-                text: mosque.flash?.content ?? '',
-                scrollAxis: Axis.horizontal,
-                blankSpace: 500,
+            child: StatefulBuilder(
+              builder: (context, setState) => TextScroll(
+                textDirection: mosque.flash?.orientation == 'rtl' ? TextDirection.rtl : TextDirection.ltr,
+                mosque.flash?.content ?? '',
+                intervalSpaces: 20,
+                velocity: Velocity(pixelsPerSecond: Offset(90, 0)),
+                delayBefore: Duration(seconds: 4),
+                pauseBetween: Duration(seconds: 2),
                 style: TextStyle(
                   height: 1,
                   fontSize: 3.4.vwr,

--- a/lib/src/pages/home/widgets/FlashWidget.dart
+++ b/lib/src/pages/home/widgets/FlashWidget.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:mawaqit/src/helpers/RelativeSizes.dart';
-import 'package:mawaqit/src/helpers/StringUtils.dart';
 import 'package:provider/provider.dart';
 import 'package:text_scroll/text_scroll.dart';
 
@@ -43,9 +42,6 @@ class FlashWidget extends StatelessWidget {
                   wordSpacing: 3,
                   shadows: kHomeTextShadow,
                   color: HexColor(mosque.flash?.color ?? "#FFFFFF"),
-                  fontFamily: StringManager.getFontFamilyByString(
-                    mosque.flash?.content ?? '',
-                  ),
                 ),
               ),
             ),

--- a/lib/src/pages/home/widgets/HadithScreen.dart
+++ b/lib/src/pages/home/widgets/HadithScreen.dart
@@ -2,7 +2,6 @@ import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:mawaqit/src/helpers/RelativeSizes.dart';
-import 'package:mawaqit/src/helpers/StringUtils.dart';
 import 'package:mawaqit/src/helpers/repaint_boundaries.dart';
 import 'package:mawaqit/src/themes/UIShadows.dart';
 
@@ -85,7 +84,6 @@ class HadithWidget extends StatelessWidget {
       style: TextStyle(
         fontSize: 6.2.vwr,
         fontWeight: FontWeight.bold,
-        fontFamily: StringManager.getFontFamilyByString(text),
         color: Colors.white,
         shadows: kAfterAdhanTextShadow,
       ),
@@ -110,7 +108,6 @@ class HadithWidget extends StatelessWidget {
             text,
             style: TextStyle(
               fontSize: 600,
-              fontFamily: StringManager.getFontFamilyByString(text),
               color: Colors.white,
               shadows: kIqamaCountDownTextShadow,
             ),

--- a/lib/src/pages/home/widgets/HomeDateWidget.dart
+++ b/lib/src/pages/home/widgets/HomeDateWidget.dart
@@ -38,7 +38,6 @@ class HomeDateWidget extends StatelessWidget {
               color: Colors.white,
               fontSize: 2.7.vwr,
               shadows: kHomeTextShadow,
-              fontFamily: StringManager.getFontFamilyByString(georgianDate),
               height: .8,
             ),
           ),
@@ -54,7 +53,6 @@ class HomeDateWidget extends StatelessWidget {
                   fontSize: 2.5.vwr,
                   height: .8,
                   shadows: kHomeTextShadow,
-                  fontFamily: StringManager.getFontFamilyByString(hijriDateFormatted),
                 ),
               ),
               if (hijriDate.isInLunarDays)

--- a/lib/src/pages/home/widgets/SalahInWidget.dart
+++ b/lib/src/pages/home/widgets/SalahInWidget.dart
@@ -51,7 +51,6 @@ class SalahInWidget extends StatelessWidget {
                       fontWeight: FontWeight.bold,
                       fontSize: 2.8.vwr,
                       color: Colors.white,
-                      fontFamily: StringManager.getFontFamilyByString(countDownText),
                       shadows: kHomeTextShadow,
                     ),
                   )
@@ -60,9 +59,7 @@ class SalahInWidget extends StatelessWidget {
                     style: TextStyle(
                       fontWeight: FontWeight.bold,
                       fontSize: 2.8.vwr,
-                      // height: 2,
                       color: Colors.white,
-                      fontFamily: StringManager.getFontFamilyByString(mosqueManager.getShurukInString(context)),
                       shadows: kHomeTextShadow,
                     ),
                   ),

--- a/lib/src/pages/home/widgets/footer.dart
+++ b/lib/src/pages/home/widgets/footer.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:mawaqit/src/helpers/RelativeSizes.dart';
-import 'package:mawaqit/src/mawaqit_image/mawaqit_image_cache.dart';
 import 'package:mawaqit/src/mawaqit_image/mawaqit_network_image.dart';
 import 'package:mawaqit/src/services/mosque_manager.dart';
 import 'package:provider/provider.dart';
@@ -44,7 +43,7 @@ class Footer extends StatelessWidget {
                       "ID ${mosque?.id}",
                       textDirection: TextDirection.ltr,
                       style: TextStyle(
-                        fontSize: .8.vw,
+                        fontSize: .8.vwr,
                         color: Colors.white,
                         fontWeight: FontWeight.bold,
                         shadows: kAfterAdhanTextShadow,

--- a/lib/src/pages/home/widgets/mosque_header.dart
+++ b/lib/src/pages/home/widgets/mosque_header.dart
@@ -35,7 +35,12 @@ class MosqueHeader extends StatelessOrientationWidget {
                 mosque.logo != null && mosqueConfig!.showLogo
                     ? Padding(
                         padding: const EdgeInsets.all(8.0),
-                        child: MawaqitNetworkImage(imageUrl: mosque.logo!, width: 40, height: 40),
+                        child: MawaqitNetworkImage(
+                          imageUrl: mosque.logo!,
+                          width: 40,
+                          height: 40,
+                          errorBuilder: (context, error, stackTrace) => SizedBox(),
+                        ),
                       )
                     : SizedBox(),
                 // SizedBox(width: 10),
@@ -69,6 +74,7 @@ class MosqueHeader extends StatelessOrientationWidget {
                           imageUrl: mosque.logo!,
                           width: 40,
                           height: 40,
+                          errorBuilder: (context, error, stackTrace) => SizedBox(),
                         ),
                       )
                     : SizedBox(),

--- a/lib/src/pages/home/widgets/mosque_header.dart
+++ b/lib/src/pages/home/widgets/mosque_header.dart
@@ -1,28 +1,27 @@
 import 'package:flutter/material.dart';
-import 'package:mawaqit/i18n/l10n.dart';
+import 'package:flutter_animate/flutter_animate.dart';
 import 'package:mawaqit/src/helpers/RelativeSizes.dart';
+import 'package:mawaqit/src/helpers/StringUtils.dart';
 import 'package:mawaqit/src/mawaqit_image/mawaqit_network_image.dart';
 import 'package:mawaqit/src/models/mosque.dart';
 import 'package:mawaqit/src/pages/home/widgets/WeatherWidget.dart';
 import 'package:mawaqit/src/pages/home/widgets/offline_widget.dart';
+import 'package:mawaqit/src/pages/home/widgets/orientation_widget.dart';
 import 'package:mawaqit/src/services/mosque_manager.dart';
 import 'package:mawaqit/src/themes/UIShadows.dart';
 import 'package:provider/provider.dart';
+import 'package:sizer/sizer.dart';
+import 'package:text_scroll/text_scroll.dart';
 
-import '../../../helpers/StringUtils.dart';
-
-class MosqueHeader extends StatelessWidget {
+class MosqueHeader extends StatelessOrientationWidget {
   const MosqueHeader({Key? key, required this.mosque}) : super(key: key);
 
   final Mosque mosque;
 
   @override
-  Widget build(BuildContext context) {
-    final mosqueManger = context.watch<MosqueManager>();
+  Widget buildLandscape(BuildContext context) {
+    final mosqueConfig = context.watch<MosqueManager>().mosqueConfig;
 
-    final mosqueConfig = mosqueManger.mosqueConfig;
-
-    final tr = S.of(context);
     return Padding(
       padding: EdgeInsets.only(top: 1.8.vh, left: .8.vw, right: .8.vw),
       child: Row(
@@ -35,68 +34,117 @@ class MosqueHeader extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 mosque.logo != null && mosqueConfig!.showLogo
-                    ? MawaqitNetworkImage(
-                        imageUrl: mosque.logo!,
-                        width: 40,
-                        height: 40,
+                    ? Padding(
+                        padding: const EdgeInsets.all(8.0),
+                        child: MawaqitNetworkImage(imageUrl: mosque.logo!, width: 40, height: 40),
                       )
                     : SizedBox(),
                 // SizedBox(width: 10),
                 Flexible(
                   child: Container(
-                      padding: EdgeInsets.only(left: 1.vw),
-                      child: FittedBox(
-                        child: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: StringManager.convertStringToList(
-                            mosqueConfig!.showCityInTitle
-                                ? mosque.name
-                                : mosque.name.contains("-")
-                                    ? mosque.name.substring(0, mosque.name.lastIndexOf("-"))
-                                    : mosque.name,
-                          ).map((e) {
-                            bool isArabicText =
-                                StringManager.arabicLetters.hasMatch(e) || StringManager.urduLetters.hasMatch(e);
-                            return Text(
-                              "$e ",
-                              style: TextStyle(
-                                  color: Colors.white,
-                                  fontSize: 4.vwr,
-                                  height: isArabicText ? 1.2 : 1,
-                                  shadows: kIqamaCountDownTextShadow,
-                                  fontWeight: FontWeight.bold,
-                                  fontFamily: isArabicText ? StringManager.fontFamilyKufi : null),
-                            );
-                          }).toList(),
+                    padding: EdgeInsets.only(left: 1.vw),
+                    child: StatefulBuilder(
+                      builder: (context, setState) => TextScroll(
+                        key: ValueKey(mosque.name.hashCode ^ SizerUtil.orientation.hashCode),
+                        mosque.name,
+                        intervalSpaces: 10,
+                        pauseBetween: 3.seconds,
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontSize: 4.vwr,
+                          height: 1.2,
+                          shadows: kIqamaCountDownTextShadow,
+                          fontWeight: FontWeight.bold,
+                          fontFamily: StringManager.fontFamilyHelvetica,
+                          fontFamilyFallback: [StringManager.fontFamilyKufi],
+                          // fontFamily: StringManager.fontFamilyKufi,
                         ),
-                      )
-
-                      // Text(
-                      //   mosque.name,
-                      //   maxLines: 1,
-                      //   style: TextStyle(
-                      //     color: Colors.white,
-                      //     fontSize: 4.vw,
-                      //     height: 1,
-                      //     shadows: kHomeTextShadow,
-                      //     fontWeight: FontWeight.bold,
-                      //     // fontFamily: StringManager.fontFamilyHelvetica
-                      //   ),
-                      // ),
                       ),
+                    ),
+                  ),
                 ),
+
                 // SizedBox(width: 10),
-                mosque.logo != null && mosqueConfig.showLogo
-                    ? MawaqitNetworkImage(
-                        imageUrl: mosque.logo!,
-                        width: 40,
-                        height: 40,
+                mosque.logo != null && mosqueConfig!.showLogo
+                    ? Padding(
+                        padding: const EdgeInsets.all(8.0),
+                        child: MawaqitNetworkImage(
+                          imageUrl: mosque.logo!,
+                          width: 40,
+                          height: 40,
+                        ),
                       )
                     : SizedBox(),
               ],
             ),
           ),
           WeatherWidget(),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget buildPortrait(BuildContext context) {
+    final mosqueConfig = context.watch<MosqueManager>().mosqueConfig;
+
+    return Padding(
+      padding: EdgeInsets.only(top: 1.8.vh, left: .8.vw, right: .8.vw),
+      child: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              OfflineWidget(),
+              WeatherWidget(),
+            ],
+          ),
+          SizedBox(height: 1.8.vh),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              if (mosque.logo != null && mosqueConfig!.showLogo)
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: MawaqitNetworkImage(imageUrl: mosque.logo!, width: 40, height: 40),
+                ),
+              Flexible(
+                child: Container(
+                  padding: EdgeInsets.only(left: 1.vw),
+                  child: StatefulBuilder(
+                    builder: (context, setState) => TextScroll(
+                      key: ValueKey(mosque.name.hashCode ^ SizerUtil.orientation.hashCode),
+                      mosque.name,
+                      intervalSpaces: 10,
+                      pauseBetween: 3.seconds,
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 4.vwr,
+                        height: 1.2,
+                        shadows: kIqamaCountDownTextShadow,
+                        fontWeight: FontWeight.bold,
+                        fontFamily: StringManager.fontFamilyHelvetica,
+                        fontFamilyFallback: [StringManager.fontFamilyKufi],
+                        // fontFamily: StringManager.fontFamilyKufi,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+
+              // SizedBox(width: 10),
+              if (mosque.logo != null && mosqueConfig!.showLogo)
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: MawaqitNetworkImage(
+                    imageUrl: mosque.logo!,
+                    width: 40,
+                    height: 40,
+                  ),
+                ),
+            ],
+          ),
         ],
       ),
     );

--- a/lib/src/pages/home/widgets/mosque_header.dart
+++ b/lib/src/pages/home/widgets/mosque_header.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:mawaqit/src/helpers/RelativeSizes.dart';
-import 'package:mawaqit/src/helpers/StringUtils.dart';
 import 'package:mawaqit/src/mawaqit_image/mawaqit_network_image.dart';
 import 'package:mawaqit/src/models/mosque.dart';
 import 'package:mawaqit/src/pages/home/widgets/WeatherWidget.dart';
@@ -55,8 +54,6 @@ class MosqueHeader extends StatelessOrientationWidget {
                           height: 1.2,
                           shadows: kIqamaCountDownTextShadow,
                           fontWeight: FontWeight.bold,
-                          fontFamily: StringManager.fontFamilyHelvetica,
-                          fontFamilyFallback: [StringManager.fontFamilyKufi],
                           // fontFamily: StringManager.fontFamilyKufi,
                         ),
                       ),
@@ -124,9 +121,6 @@ class MosqueHeader extends StatelessOrientationWidget {
                         height: 1.2,
                         shadows: kIqamaCountDownTextShadow,
                         fontWeight: FontWeight.bold,
-                        fontFamily: StringManager.fontFamilyHelvetica,
-                        fontFamilyFallback: [StringManager.fontFamilyKufi],
-                        // fontFamily: StringManager.fontFamilyKufi,
                       ),
                     ),
                   ),

--- a/lib/src/pages/home/widgets/mosque_header.dart
+++ b/lib/src/pages/home/widgets/mosque_header.dart
@@ -48,8 +48,8 @@ class MosqueHeader extends StatelessOrientationWidget {
                   child: Container(
                     padding: EdgeInsets.only(left: 1.vw),
                     child: StatefulBuilder(
+                      key: ValueKey(mosque.name.hashCode ^ SizerUtil.orientation.hashCode),
                       builder: (context, setState) => TextScroll(
-                        key: ValueKey(mosque.name.hashCode ^ SizerUtil.orientation.hashCode),
                         mosque.name,
                         intervalSpaces: 10,
                         pauseBetween: 3.seconds,

--- a/lib/src/pages/home/widgets/offline_widget.dart
+++ b/lib/src/pages/home/widgets/offline_widget.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:mawaqit/i18n/l10n.dart';
-import 'package:mawaqit/src/helpers/Api.dart';
 import 'package:mawaqit/src/helpers/RelativeSizes.dart';
-import 'package:mawaqit/src/helpers/StringUtils.dart';
 import 'package:mawaqit/src/services/mosque_manager.dart';
 import 'package:mawaqit/src/themes/UIShadows.dart';
 import 'package:provider/provider.dart';
@@ -23,8 +21,7 @@ class OfflineWidget extends StatelessWidget {
           SizedBox(width: 1.vw),
           CircleAvatar(
             radius: .6.vwr,
-            backgroundColor:
-                mosqueManager.isOnline ? Colors.green : Colors.red[700],
+            backgroundColor: mosqueManager.isOnline ? Colors.green : Colors.red[700],
           ),
           SizedBox(width: .4.vwr),
           Text(
@@ -35,7 +32,6 @@ class OfflineWidget extends StatelessWidget {
               fontSize: 1.5.vwr,
               height: 1.1,
               fontWeight: FontWeight.w400,
-              fontFamily: StringManager.getFontFamilyByString(tr.online),
             ),
           ),
         ],

--- a/lib/src/pages/home/widgets/salah_items/SalahItem.dart
+++ b/lib/src/pages/home/widgets/salah_items/SalahItem.dart
@@ -5,7 +5,6 @@ import 'package:mawaqit/src/themes/UIShadows.dart';
 import 'package:mawaqit/src/widgets/time_widget.dart';
 import 'package:provider/provider.dart';
 
-import '../../../../helpers/StringUtils.dart';
 import '../../../../services/mosque_manager.dart';
 
 class SalahItemWidget extends StatelessWidget {
@@ -69,10 +68,10 @@ class SalahItemWidget extends StatelessWidget {
                 maxLines: 1,
                 title ?? "",
                 style: TextStyle(
-                    fontSize: titleFont,
-                    shadows: kHomeTextShadow,
-                    color: Colors.white,
-                    fontFamily: StringManager.getFontFamilyByString(title ?? "")),
+                  fontSize: titleFont,
+                  shadows: kHomeTextShadow,
+                  color: Colors.white,
+                ),
               ),
             ),
           SizedBox(height: isArabic ? 0.1.vh : 1.vh),

--- a/lib/src/pages/home/widgets/salah_items/SalahItem.dart
+++ b/lib/src/pages/home/widgets/salah_items/SalahItem.dart
@@ -1,16 +1,12 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart' hide TextDirection;
 import 'package:mawaqit/i18n/AppLanguage.dart';
 import 'package:mawaqit/src/helpers/RelativeSizes.dart';
-import 'package:mawaqit/src/helpers/time_utils.dart';
 import 'package:mawaqit/src/themes/UIShadows.dart';
 import 'package:mawaqit/src/widgets/time_widget.dart';
 import 'package:provider/provider.dart';
 
 import '../../../../helpers/StringUtils.dart';
 import '../../../../services/mosque_manager.dart';
-
-const kSalahItemWidgetWidth = 135.0;
 
 class SalahItemWidget extends StatelessWidget {
   SalahItemWidget({
@@ -40,23 +36,21 @@ class SalahItemWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    double bigFont = 4.5.vwr;
-    double smallFont = 3.6.vwr;
+    double titleFont = 3.vw;
+    double bigFont = 4.5.vw;
+    double smallFont = 3.6.vw;
 
     final mosqueProvider = context.watch<MosqueManager>();
     final mosqueConfig = mosqueProvider.mosqueConfig;
-    final timeDate = time.toTimeOfDay()?.toDate(mosqueProvider.mosqueDate());
-    final iqamaDate = iqama?.toTimeOfDay()?.toDate(mosqueProvider.mosqueDate());
     // print(isIqamaEnabled);
     final isArabic = context.read<AppLanguage>().isArabic();
 
     final is12period = mosqueConfig?.timeDisplayFormat == "12";
-    final DateFormat dateTimeConverter = is12period ? DateFormat("hh:mm", "en-En") : DateFormat("HH:mm", "en");
 
     return Container(
-      width: 16.vwr,
+      width: 16.vw,
       decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(2.vwr),
+        borderRadius: BorderRadius.circular(2.vw),
         color: active
             ? mosqueProvider.getColorTheme().withOpacity(.5)
             : removeBackground
@@ -75,7 +69,7 @@ class SalahItemWidget extends StatelessWidget {
                 maxLines: 1,
                 title ?? "",
                 style: TextStyle(
-                    fontSize: 3.vwr,
+                    fontSize: titleFont,
                     shadows: kHomeTextShadow,
                     color: Colors.white,
                     fontFamily: StringManager.getFontFamilyByString(title ?? "")),
@@ -83,7 +77,7 @@ class SalahItemWidget extends StatelessWidget {
             ),
           SizedBox(height: isArabic ? 0.1.vh : 1.vh),
           if (time.trim().isEmpty)
-            Icon(Icons.dnd_forwardslash, size: 6.vwr)
+            Icon(Icons.dnd_forwardslash, size: 6.vw)
           else
             FittedBox(
               fit: BoxFit.scaleDown,
@@ -101,7 +95,7 @@ class SalahItemWidget extends StatelessWidget {
             ),
           if (iqama != null && showIqama)
             SizedBox(
-              height: isArabic ? 1.5.vh : 1.3.vwr,
+              height: isArabic ? 1.5.vh : 1.3.vw,
               width: double.infinity,
               child: Divider(
                 thickness: 1,

--- a/lib/src/pages/home/widgets/salah_items/horizontal_salah_item.dart
+++ b/lib/src/pages/home/widgets/salah_items/horizontal_salah_item.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:mawaqit/src/helpers/RelativeSizes.dart';
-import 'package:mawaqit/src/helpers/StringUtils.dart';
 import 'package:mawaqit/src/services/mosque_manager.dart';
 import 'package:mawaqit/src/themes/UIShadows.dart';
 import 'package:mawaqit/src/widgets/iqama_time_widget.dart';
@@ -72,7 +71,6 @@ class HorizontalSalahItem extends StatelessWidget {
                     fontSize: titleFont,
                     shadows: kHomeTextShadow,
                     color: Colors.white,
-                    fontFamily: StringManager.getFontFamilyByString(title ?? ""),
                   ),
                 ),
               ),

--- a/lib/src/pages/home/widgets/salah_items/horizontal_salah_item.dart
+++ b/lib/src/pages/home/widgets/salah_items/horizontal_salah_item.dart
@@ -39,8 +39,9 @@ class HorizontalSalahItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    double bigFont = 4.5.vwr;
-    double smallFont = 3.6.vwr;
+    double titleFont = 3.vwr;
+    double bigFont = 3.5.vwr;
+    double smallFont = 2.6.vwr;
 
     final mosqueProvider = context.watch<MosqueManager>();
     final mosqueConfig = mosqueProvider.mosqueConfig;
@@ -68,7 +69,7 @@ class HorizontalSalahItem extends StatelessWidget {
                   maxLines: 1,
                   title ?? "",
                   style: TextStyle(
-                    fontSize: 4.vwr,
+                    fontSize: titleFont,
                     shadows: kHomeTextShadow,
                     color: Colors.white,
                     fontFamily: StringManager.getFontFamilyByString(title ?? ""),

--- a/lib/src/pages/home/widgets/salah_items/mini_horizontal_salah_item.dart
+++ b/lib/src/pages/home/widgets/salah_items/mini_horizontal_salah_item.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:mawaqit/src/helpers/RelativeSizes.dart';
-import 'package:mawaqit/src/helpers/StringUtils.dart';
 import 'package:mawaqit/src/services/mosque_manager.dart';
 import 'package:mawaqit/src/themes/UIShadows.dart';
 import 'package:mawaqit/src/widgets/time_widget.dart';
@@ -54,7 +53,6 @@ class MiniHorizontalSalahItem extends StatelessWidget {
                 fontSize: 4.vwr,
                 shadows: kHomeTextShadow,
                 color: Colors.white,
-                fontFamily: StringManager.getFontFamilyByString(title ?? ""),
               ),
             ),
             SizedBox(width: 3.vw),

--- a/lib/src/services/theme_manager.dart
+++ b/lib/src/services/theme_manager.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mawaqit/src/helpers/StringUtils.dart';
 
 import './storage_manager.dart';
 
@@ -35,11 +36,10 @@ class ThemeNotifier with ChangeNotifier {
             return Colors.grey;
           }),
         ),
-        textTheme: ThemeData().textTheme.apply(
-              bodyColor: Colors.white,
-              displayColor: Colors.white,
-              decorationColor: Colors.white,
-            ),
+        textTheme: Typography.material2014().white.apply(
+          fontFamily: StringManager.fontFamilyHelvetica,
+          fontFamilyFallback: [StringManager.fontFamilyKufi],
+        ),
         outlinedButtonTheme: OutlinedButtonThemeData(
           style: ButtonStyle(
             overlayColor: MaterialStateProperty.all(Color(0xff490094)),

--- a/lib/src/widgets/TimePeriodWidget.dart
+++ b/lib/src/widgets/TimePeriodWidget.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart' hide TextDirection;
 import 'package:mawaqit/i18n/AppLanguage.dart';
-import 'package:mawaqit/src/helpers/StringUtils.dart';
 import 'package:provider/provider.dart';
 
 class TimePeriodWidget extends StatelessWidget {
@@ -28,10 +27,7 @@ class TimePeriodWidget extends StatelessWidget {
     return Text(
       maxLines: 2,
       value,
-      style: (style ?? defaultStyle).apply(
-        fontFamily: StringManager.getFontFamilyByString(value),
-        fontSizeFactor: isArabic ? 1.2 : 1,
-      ),
+      style: (style ?? defaultStyle).apply(fontSizeFactor: isArabic ? 1.2 : 1),
     );
   }
 }

--- a/lib/src/widgets/mosque_simple_tile.dart
+++ b/lib/src/widgets/mosque_simple_tile.dart
@@ -77,25 +77,26 @@ class _MosqueSimpleTileState extends State<MosqueSimpleTile> {
                   ),
                 ),
                 SizedBox(width: 8),
-                Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      widget.mosque.label ?? widget.mosque.name,
-                      style: theme.textTheme.titleMedium,
-                    ),
-                    SizedBox(height: 2),
-                    SizedBox(
-                      width: 45.vw,
-                      child: Text(
-                        overflow: TextOverflow.ellipsis,
-                        widget.mosque.localisation ?? '',
-                        style: theme.textTheme.bodySmall,
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        widget.mosque.label ?? widget.mosque.name,
+                        style: theme.textTheme.titleMedium,
                       ),
-                    ),
-                  ],
+                      SizedBox(height: 2),
+                      SizedBox(
+                        width: 45.vw,
+                        child: Text(
+                          overflow: TextOverflow.ellipsis,
+                          widget.mosque.localisation ?? '',
+                          style: theme.textTheme.bodySmall,
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
-                Spacer(),
                 if (loading) Padding(padding: EdgeInsets.symmetric(horizontal: 20), child: CircularProgressIndicator()),
               ],
             ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -80,7 +80,7 @@ dependencies:
 
   auto_size_text: ^3.0.0
   flutter_animate: ^4.1.1+1
-  marquee: ^2.2.3
+  text_scroll: ^0.2.0
 
   easy_debounce: ^2.0.3
 


### PR DESCRIPTION
# Logic 

## Mosque title 
1. center title in the middle. If it can fit in the available width 
2. if the title is too big auto-scroll it like the bottom flash message 
3. in portrait mode add the title in a second row after the online widget, weather widget

## Home screen sizing 
1. Reduce the text size on the salah item so the content can fit on the screen 

## Font family 
### Issue 
- We were splitting strings into and rendering the Arabic with Kufi font and other characters in another font 

### Logic 
- Solved by adding font family fallback globally in the theme so Flutter handle this for us 
- Remove all the font family setters in the code 


## Mosque tile 
### issue
- Mosque tile had a rendering issue with row overt flow 
### Solved
- by wrapping the title in Expanded to take only the remaining space