### PR TITLE
Add offline manual hijri adjustments on devices locally 

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -159,5 +159,9 @@
   "takbeerAleidText": "Allahu Akbar, Allahu Akbar, Allahu Akbar, la ilaha illa Allah, Allahu Akbar, Allahu Akbar, wa lillahi al-hamd",
   "settings": "Settings",
   "applicationModes": "Application Modes",
-  "ifYouAreFacingAnIssueWithTheAppActivateThis": "If you are facing issues with the app, try to enable this option"
+  "ifYouAreFacingAnIssueWithTheAppActivateThis": "If you are facing issues with the app, try to enable this option",
+  "hijriAdjustments": "Local Hijri adjustments",
+  "hijriAdjustmentsDescription": "Adjust the hijri date locally in your device. This will not affect the online mosque settings",
+  "backoffice_default": "Backoffice Defaults",
+  "recommended": "Recommended"
 }

--- a/lib/src/models/calendar/MawaqitHijriCalendar.dart
+++ b/lib/src/models/calendar/MawaqitHijriCalendar.dart
@@ -1,4 +1,3 @@
-import 'package:intl/intl.dart';
 import 'package:mawaqit/i18n/l10n.dart';
 import 'package:mawaqit/src/helpers/StringUtils.dart';
 
@@ -15,8 +14,6 @@ class MawaqitHijriCalendar extends KuwaitiCalendar {
   }) : super.fromDatetime(date, dayShift: adjustment, force30: force30Days);
 
   String formatMawaqitType() {
-    final dayFormatter = DateFormat('EEEE', S.current.localeName);
-
     return [
       islamicDate.toString(),
       '${monthName(islamicMonth)},',

--- a/lib/src/pages/HijriAdjustmentsScreen.dart
+++ b/lib/src/pages/HijriAdjustmentsScreen.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:mawaqit/i18n/l10n.dart';
+import 'package:mawaqit/src/models/calendar/MawaqitHijriCalendar.dart';
+import 'package:mawaqit/src/services/mosque_manager.dart';
+import 'package:mawaqit/src/services/user_preferences_manager.dart';
+import 'package:mawaqit/src/widgets/ScreenWithAnimation.dart';
+import 'package:provider/provider.dart';
+
+class HijriAdjustmentsScreen extends StatelessWidget {
+  const HijriAdjustmentsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final mosqueManager = Provider.of<MosqueManager>(context);
+    final userPrefs = Provider.of<UserPreferencesManager>(context);
+
+    return Scaffold(
+      body: ScreenWithAnimationWidget(
+        animation: 'settings',
+        child: Center(
+          child: ListView(
+            shrinkWrap: true,
+            children: [
+              Text(
+                S.of(context).hijriAdjustments,
+                style: Theme.of(context).textTheme.titleMedium?.apply(fontSizeFactor: 2),
+                textAlign: TextAlign.center,
+              ),
+              SizedBox(height: 20),
+              Text(
+                S.of(context).hijriAdjustmentsDescription,
+                style: Theme.of(context).textTheme.bodyLarge?.apply(fontSizeFactor: 1.2),
+                textAlign: TextAlign.center,
+              ),
+              Divider(indent: 50, endIndent: 50),
+              SizedBox(height: 20),
+              ListTile(
+                autofocus: userPrefs.hijriAdjustments == null,
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+                onTap: () {
+                  userPrefs.hijriAdjustments = null;
+                  Navigator.pop(context);
+                },
+                title: Text('${S.current.backoffice_default}'),
+                subtitle: Text('${S.current.recommended}'),
+                trailing: Text(
+                  MawaqitHijriCalendar.fromDateWithAdjustments(
+                    mosqueManager.mosqueDate(),
+                    adjustment: mosqueManager.times?.hijriAdjustment ?? 0,
+                    force30Days: mosqueManager.times?.hijriDateForceTo30 ?? false,
+                  ).formatMawaqitType(),
+                ),
+              ),
+              for (var i = -2; i <= 2; i++)
+                ListTile(
+                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+                  autofocus: userPrefs.hijriAdjustments == i,
+                  onTap: () {
+                    userPrefs.hijriAdjustments = i;
+                    Navigator.pop(context);
+                  },
+                  title: Text(i > 0 ? '+$i' : '$i'),
+                  trailing: Text(
+                    MawaqitHijriCalendar.fromDateWithAdjustments(
+                      mosqueManager.mosqueDate(),
+                      adjustment: i,
+                      force30Days: mosqueManager.times?.hijriDateForceTo30 ?? false,
+                    ).formatMawaqitType(),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/pages/SettingScreen.dart
+++ b/lib/src/pages/SettingScreen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:mawaqit/i18n/l10n.dart';
 import 'package:mawaqit/src/helpers/AppRouter.dart';
 import 'package:mawaqit/src/helpers/mawaqit_icons_icons.dart';
+import 'package:mawaqit/src/pages/HijriAdjustmentsScreen.dart';
 import 'package:mawaqit/src/pages/LanguageScreen.dart';
 import 'package:mawaqit/src/pages/MosqueSearchScreen.dart';
 import 'package:mawaqit/src/pages/onBoarding/widgets/OrientationWidget.dart';
@@ -49,6 +50,12 @@ class SettingScreen extends StatelessWidget {
                     subtitle: S.of(context).searchMosque,
                     icon: Icon(MawaqitIcons.icon_mosque, size: 35),
                     onTap: () => AppRouter.push(MosqueSearchScreen()),
+                  ),
+                  _SettingItem(
+                    title: S.of(context).hijriAdjustments,
+                    subtitle: S.of(context).hijriAdjustmentsDescription,
+                    icon: Icon(MawaqitIcons.icon_mosque, size: 35),
+                    onTap: () => AppRouter.push(HijriAdjustmentsScreen()),
                   ),
                   SizedBox(height: 30),
                   Divider(),

--- a/lib/src/pages/home/widgets/HomeDateWidget.dart
+++ b/lib/src/pages/home/widgets/HomeDateWidget.dart
@@ -5,6 +5,7 @@ import 'package:mawaqit/src/helpers/RelativeSizes.dart';
 import 'package:mawaqit/src/helpers/StringUtils.dart';
 import 'package:mawaqit/src/pages/home/widgets/FadeInOut.dart';
 import 'package:mawaqit/src/services/mosque_manager.dart';
+import 'package:mawaqit/src/services/user_preferences_manager.dart';
 import 'package:mawaqit/src/themes/UIShadows.dart';
 import 'package:provider/provider.dart';
 
@@ -14,10 +15,11 @@ class HomeDateWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final mosqueManager = context.watch<MosqueManager>();
+    final userPrefs = context.watch<UserPreferencesManager>();
     final now = mosqueManager.mosqueDate();
     final lang = Localizations.localeOf(context).languageCode;
 
-    var hijriDate = mosqueManager.mosqueHijriDate();
+    var hijriDate = mosqueManager.mosqueHijriDate(userPrefs.hijriAdjustments);
     var hijriDateFormatted = hijriDate.formatMawaqitType();
 
     final georgianDate = now.formatIntoMawaqitFormat(local: '${lang}_${mosqueManager.mosque?.countryCode}');

--- a/lib/src/pages/home/widgets/ShurukWidget.dart
+++ b/lib/src/pages/home/widgets/ShurukWidget.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
-import 'package:mawaqit/main.dart';
 import 'package:mawaqit/src/pages/home/widgets/FadeInOut.dart';
+import 'package:mawaqit/src/services/user_preferences_manager.dart';
 import 'package:provider/provider.dart';
 
 import '../../../../i18n/l10n.dart';
@@ -16,8 +16,9 @@ class ShurukWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final mosqueProvider = context.read<MosqueManager>();
+    final userPrefs = context.read<UserPreferencesManager>();
 
-    if (mosqueProvider.showEid) {
+    if (mosqueProvider.showEid(userPrefs.hijriAdjustments)) {
       return SalahItemWidget(
         title: S.of(context).salatElEid,
         iqama: mosqueProvider.times!.aidPrayerTime2,

--- a/lib/src/pages/home/workflow/normal_workflow.dart
+++ b/lib/src/pages/home/workflow/normal_workflow.dart
@@ -1,16 +1,12 @@
 import 'dart:async';
-import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
-import 'package:mawaqit/src/enum/home_active_screen.dart';
-import 'package:mawaqit/src/helpers/AppRouter.dart';
 import 'package:mawaqit/src/pages/home/sub_screens/AnnouncementScreen.dart';
 import 'package:mawaqit/src/pages/home/sub_screens/RandomHadithScreen.dart';
 import 'package:mawaqit/src/pages/home/sub_screens/fajr_wake_up_screen.dart';
 import 'package:mawaqit/src/pages/home/sub_screens/normal_home.dart';
 import 'package:mawaqit/src/pages/home/sub_screens/takberat_aleid_screen.dart';
-import 'package:mawaqit/src/pages/home/widgets/mosque_background_screen.dart';
 import 'package:mawaqit/src/pages/home/widgets/workflows/repeating_workflow_widget.dart';
 import 'package:mawaqit/src/services/mosque_manager.dart';
 import 'package:mawaqit/src/services/user_preferences_manager.dart';
@@ -100,7 +96,7 @@ class _NormalWorkflowScreenState extends State<NormalWorkflowScreen> {
           builder: (context, next) => TakberatAleidScreen(),
           dateTime: mosqueManager.actualTimes()[0].add(1.hours),
           endTime: mosqueManager.actualTimes()[0].add(3.hours),
-          disabled: !mosqueManager.isEidFirstDay,
+          disabled: !mosqueManager.isEidFirstDay(userPrefs.hijriAdjustments),
           forceStart: true,
           showInitial: () {
             final now = mosqueManager.mosqueDate();

--- a/lib/src/pages/home/workflow/salah_workflow.dart
+++ b/lib/src/pages/home/workflow/salah_workflow.dart
@@ -10,6 +10,7 @@ import 'package:mawaqit/src/pages/home/sub_screens/IqamaaCountDownSubScreen.dart
 import 'package:mawaqit/src/pages/home/sub_screens/normal_home.dart';
 import 'package:mawaqit/src/pages/home/widgets/workflows/repeating_workflow_widget.dart';
 import 'package:mawaqit/src/services/mosque_manager.dart';
+import 'package:mawaqit/src/services/user_preferences_manager.dart';
 import 'package:provider/provider.dart';
 
 import '../sub_screens/AdhanSubScreen.dart';
@@ -63,8 +64,9 @@ class _SalahWorkflowScreenState extends State<SalahWorkflowScreen> {
   Widget build(BuildContext context) {
     final mosqueManger = context.watch<MosqueManager>();
     final mosqueConfig = mosqueManger.mosqueConfig!;
+    final userPrefs = context.watch<UserPreferencesManager>();
 
-    final hijri = mosqueManger.mosqueHijriDate();
+    final hijri = mosqueManger.mosqueHijriDate(userPrefs.hijriAdjustments);
 
     final currentSalah = calculateCurrentSalah(mosqueManger);
     final now = mosqueManger.mosqueDate();

--- a/lib/src/services/mixins/mosque_helpers_mixins.dart
+++ b/lib/src/services/mixins/mosque_helpers_mixins.dart
@@ -107,16 +107,16 @@ mixin MosqueHelpersMixin on ChangeNotifier {
   }
 
   /// return true if today is the eid first day
-  bool get isEidFirstDay {
-    final hijri = mosqueHijriDate();
+  bool isEidFirstDay(int? hijriAdjustment) {
+    final hijri = mosqueHijriDate(hijriAdjustment);
 
     return (hijri.islamicMonth == 9 && hijri.islamicDate == 1) || (hijri.islamicMonth == 11 && hijri.islamicDate == 10);
   }
 
-  bool get showEid {
+  bool showEid(int? hijriAdjustment) {
     if (times!.aidPrayerTime == null && times!.aidPrayerTime2 == null) return false;
 
-    final date = mosqueHijriDate();
+    final date = mosqueHijriDate(hijriAdjustment);
     return (date.islamicMonth == 8 && date.islamicDate >= 23) ||
         (date.islamicMonth == 9 && date.islamicDate == 1) ||
         (date.islamicMonth == 11 && date.islamicDate < 11 && date.islamicDate >= 3);
@@ -228,10 +228,10 @@ mixin MosqueHelpersMixin on ChangeNotifier {
   /// used to test time
   TimeOfDay mosqueTimeOfDay() => TimeOfDay.fromDateTime(mosqueDate());
 
-  MawaqitHijriCalendar mosqueHijriDate() => MawaqitHijriCalendar.fromDateWithAdjustments(
+  MawaqitHijriCalendar mosqueHijriDate(int? forceAdjustment) => MawaqitHijriCalendar.fromDateWithAdjustments(
         mosqueDate(),
         force30Days: times!.hijriDateForceTo30,
-        adjustment: times!.hijriAdjustment,
+        adjustment: forceAdjustment ?? times!.hijriAdjustment,
       );
 
   bool get useTomorrowTimes {

--- a/lib/src/services/user_preferences_manager.dart
+++ b/lib/src/services/user_preferences_manager.dart
@@ -10,6 +10,7 @@ const _secondaryScreenKey = 'UserPreferencesManager.secondary.screen.enabled';
 const _webViewModeKey = 'UserPreferencesManager.webView.mode.enabled';
 const _forceStagingKey = 'UserPreferencesManager.api.settings.staging';
 const _screenOrientation = 'UserPreferencesManager.screen.orientation';
+const _hijriAdjustments = 'UserPreferencesManager.hijriAdjustments';
 
 /// this manager responsible for managing user preferences
 class UserPreferencesManager extends ChangeNotifier {
@@ -113,5 +114,16 @@ class UserPreferencesManager extends ChangeNotifier {
       default:
         return RelativeSizes.instance.orientation;
     }
+  }
+
+  int? get hijriAdjustments => _sharedPref.getInt(_hijriAdjustments);
+
+  set hijriAdjustments(int? value) {
+    if (value == null) {
+      _sharedPref.remove(_hijriAdjustments);
+    } else {
+      _sharedPref.setInt(_hijriAdjustments, value);
+    }
+    notifyListeners();
   }
 }


### PR DESCRIPTION
# Logic 

1. User can override his hijri date adjustments locally on his device 
2. This effect will affect the device 
3. All calculations related to the Hijri date will be affected like (showEid, lunar day, ...etc)


# UI Screenshots 

- ![Screenshot_1690124710](https://github.com/mawaqit/android-tv-app/assets/63953869/328ae705-82f4-499f-bf2d-41e4ac7275da)
- ![Screenshot_1690124696](https://github.com/mawaqit/android-tv-app/assets/63953869/b2f65033-275f-450a-89f6-1dbffd481bfa)

