### PR TITLE
enable sound on mosque secondary screen

### DIFF
--- a/lib/src/pages/home/sub_screens/JummuaLive.dart
+++ b/lib/src/pages/home/sub_screens/JummuaLive.dart
@@ -46,7 +46,6 @@ class _JummuaLiveState extends State<JummuaLive> {
     return MawaqitYoutubePlayer(
       channelId: mosqueManager.mosque!.streamUrl!,
       onDone: widget.onDone,
-      muted: mosqueManager.typeIsMosque,
       onNotFound: () => setState(() => invalidStreamUrl = true),
     );
   }


### PR DESCRIPTION
# Old state 

We were showing the Jumua live in 
- everywhere rather than mosque 
- In the mosque secondary screen 

The Jumuaa live was muted only in the mosque's secondary screen 


# Content update 

- Unmute the jumuaa live on the secondary screen of the mosque 