### PR TITLE
use random uuid to identify the device

### DIFF
--- a/lib/src/services/user_preferences_manager.dart
+++ b/lib/src/services/user_preferences_manager.dart
@@ -18,11 +18,13 @@ class UserPreferencesManager extends ChangeNotifier {
     init();
   }
 
-  Future<void> init() async {
+  Future<UserPreferencesManager> init() async {
     _sharedPref = await SharedPreferences.getInstance();
 
     Api.useStagingApi(forceStaging);
     forceOrientation();
+
+    return this;
   }
 
   late SharedPreferences _sharedPref;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -106,7 +106,6 @@ dependencies:
   youtube_player_flutter: ^8.1.2
   youtube_explode_dart: ^1.12.4
   audiofileplayer: ^2.1.1
-  unique_identifier: ^0.3.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
# Issue 
Using the device-specific ID is not compliant with our Policy 

# Resolve 
Generate A Random UUID to act like the device ID 

# Logic 
1. In the initial app will generate V5 UUID 
2. Then will save it in the shared preferences 
3. After that the saved UUID will be used in all requests to act like a Device-ID