### PR TITLE
fix weather icon color

### DIFF
--- a/lib/src/pages/home/widgets/WeatherWidget.dart
+++ b/lib/src/pages/home/widgets/WeatherWidget.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:mawaqit/src/helpers/HexColor.dart';
 import 'package:mawaqit/src/helpers/RelativeSizes.dart';
 import 'package:mawaqit/src/helpers/weather_icons.dart';
 import 'package:mawaqit/src/services/mosque_manager.dart';
@@ -44,19 +43,21 @@ class WeatherWidget extends StatelessWidget {
         Text(
           "$temperature",
           style: Theme.of(context).textTheme.titleLarge?.copyWith(
-              fontSize: 3.vwr,
-              fontWeight: FontWeight.w700,
-              color: HexColor(mosqueManager.getColorFeeling()),
-              shadows: kHomeTextShadow),
+                fontSize: 3.vwr,
+                fontWeight: FontWeight.w700,
+                color: mosqueManager.getColorFeeling(),
+                shadows: kHomeTextShadow,
+              ),
         ),
         Text(
           "°$temperatureUnit",
           style: TextStyle(
-              fontWeight: FontWeight.w700,
-              height: 1,
-              color: HexColor(mosqueManager.getColorFeeling()),
-              fontSize: 2.4.vwr,
-              shadows: kHomeTextShadow),
+            fontWeight: FontWeight.w700,
+            height: 1,
+            color: mosqueManager.getColorFeeling(),
+            fontSize: 2.4.vwr,
+            shadows: kHomeTextShadow,
+          ),
         ),
       ],
     );

--- a/lib/src/services/mixins/weather_mixin.dart
+++ b/lib/src/services/mixins/weather_mixin.dart
@@ -22,27 +22,23 @@ mixin WeatherMixin on ChangeNotifier {
       });
   }
 
-  String getColorFeeling() {
-    String? feeling = weather?.feeling;
-    String color = "#FFFFFF";
-    switch (feeling) {
-      case "very-hot":
-        color = "#AA3333";
-        return color;
-      case "hot":
-        color = "#d58512";
-        return color;
-      case "middle":
-        color = "#ffd05f";
-        return color;
-      case "cold":
-        color = "#FFFFFF";
-        return color;
-      case "very-cold":
-        color = "#3498db";
-        return color;
+  Color getColorFeeling() {
+    final temp = weather?.temperature;
+
+    switch (temp) {
+      case null:
+        return Colors.white;
+      case <= 0:
+        return Color(0xFF3498DB); // very cold
+      case <= 10:
+        return Color(0xFFFFFFFF); // cold
+      case <= 20:
+        return Color(0xFFFFD05F); // middle
+      case <= 30:
+        return Color(0xFFD58512); // hot
+      default:
+        return Color(0xFFAA3333); // very hot
     }
-    return color;
   }
 
   Color getColorTheme() {


### PR DESCRIPTION
# Issue 
-  we were using felling (verry hot, hot, ... etc.) to get the color of the weather temperature. 

# Resolve 
- using the temperature value to calculate it

![Screenshot_1693822480](https://github.com/mawaqit/android-tv-app/assets/63953869/975e9bf3-88b4-4c32-81fb-a46cbcb23fe1)
![Screenshot_1693822498](https://github.com/mawaqit/android-tv-app/assets/63953869/e315fbe0-e96d-4449-bc4d-05e8ff81f0e2)
![Screenshot_1693822516](https://github.com/mawaqit/android-tv-app/assets/63953869/747b90ae-7a17-431b-9e5d-608dec510f0c)
![Screenshot_1693822544](https://github.com/mawaqit/android-tv-app/assets/63953869/13809756-0d85-49d4-9002-657d9e068c5c)
![Screenshot_1693822570](https://github.com/mawaqit/android-tv-app/assets/63953869/404af692-fe42-45d1-93e7-b82b8ada8d7b)

