### PR TITLE
Update weather_icons.dart

### DIFF
--- a/lib/src/helpers/weather_icons.dart
+++ b/lib/src/helpers/weather_icons.dart
@@ -7,7 +7,7 @@ class WeatherIcons extends IconData {
     return _values[value] ??
         _values["day-$value"] ??
         _values["night-$value"] ??
-        day_sunny;
+        degrees;
   }
 
   factory WeatherIcons.fromStringWithDateNight(
@@ -26,6 +26,7 @@ class WeatherIcons extends IconData {
     "day-fog": day_fog,
     "day-hail": day_hail,
     "day-haze": day_haze,
+    "haze": day_haze,
     "day-lightning": day_lightning,
     "day-rain": day_rain,
     "day-rain-mix": day_rain_mix,


### PR DESCRIPTION
# Issue 
1. The icon was not found so the app was showing a sunny icon on the night 

# Solve 
1. check the backend strings to see if there are any icons that may possibly not be found on the mobile side 
2. The Haze icon was only available as a day-hazy 
3. Added it as hazy should fix the issue 

# Icons logic 
1. Mobile gets the icon from the backend API 
2. add day- or night- as a prefix to the icon name based on maghrib salah 
3. if the icon isn't found will test without the prefix (so night-haze will not be found so will test haze)

# Default icon if there is no icon match 
- this icon shouldn't be visible to end user, its an indication of error 
- the default icon was sunny replaced it with degree icon that will not be noticeable to end users 