### PR TITLE
fix invalid argument  onError

### DIFF
--- a/lib/src/services/mixins/weather_mixin.dart
+++ b/lib/src/services/mixins/weather_mixin.dart
@@ -17,7 +17,7 @@ mixin WeatherMixin on ChangeNotifier {
 
   void loadWeather(Mosque mosque) async {
     if (mosque.uuid != null) {
-      _weatherSubscription?.cancel().catchError(() {});
+      _weatherSubscription?.cancel().catchError((e) {});
 
       _weatherSubscription = generateStream(Duration(hours: 1)).listen((event) => Api.getWeather(mosque.uuid!).then((value) {
             weather = value;


### PR DESCRIPTION
Fix sentry issue 
```
ArgumentError: Invalid argument (onError): Error handler must accept one Object or one Object and a StackTrace as arguments, and return a value of the returned future's type: Closure: () => Null
  File "weather_mixin.dart", line 20, in WeatherMixin.loadWeather
  File "mosque_manager.dart", line 163, in MosqueManager.fetchMosque
  File "mosque_manager.dart", line 68, in MosqueManager.setMosqueUUid
  File "mosque_simple_tile.dart", line 61, in _MosqueSimpleTileState.build.<fn>
...
(3 additional frame(s) were not displayed)
```