### PR TITLE
fix background image network leak

### DIFF
--- a/lib/src/models/mosqueConfig.dart
+++ b/lib/src/models/mosqueConfig.dart
@@ -29,7 +29,7 @@ class MosqueConfig {
   final bool? iqamaFullScreenCountdown;
   final String? theme;
 
-  String get motifUrl => 'https://mawaqit.net/bundles/app/prayer-times/img/background/${backgroundMotif ?? 5}.jpg';
+  String get motifUrl => 'https://mawaqit.net/prayer-times/img/background/${backgroundMotif ?? 5}.jpg';
 
 //<editor-fold desc="Data Methods">
 

--- a/lib/src/pages/home/widgets/mosque_background_screen.dart
+++ b/lib/src/pages/home/widgets/mosque_background_screen.dart
@@ -60,7 +60,7 @@ class _MosqueBackgroundScreenState extends State<MosqueBackgroundScreen> {
                       onError: (exception, stackTrace) {},
                     ),
                   ),
-            child: Container(child: widget.child),
+            child: RepaintBoundary(child: widget.child),
           ),
         ),
       ),


### PR DESCRIPTION
# Issue 
1. The Mawaqit background image widget was making requests each second to re-fetch the image from the (cache or internet)
2. The mosque config motif URL is invalid 

# Fixes 
1. add Repaintboundry to the screen content to separate it from the background so they don't affect each other 
2. restructure the motif URL generator function  