### PR TITLE
#929 brackets are inverted on rtl languages

### DIFF
--- a/lib/src/helpers/font_manager.dart
+++ b/lib/src/helpers/font_manager.dart
@@ -1,0 +1,14 @@
+import 'package:google_fonts/google_fonts.dart';
+
+class FontManager {
+ static String? getFontFamily(String local) {
+    switch (local) {
+      case 'ar':
+        return GoogleFonts.amiri().fontFamily;
+      case 'tr':
+        return GoogleFonts.amiri().fontFamily;
+      default:
+        return null;
+    }
+  }
+}

--- a/lib/src/pages/home/sub_screens/AfterAdhanHadithSubScreen.dart
+++ b/lib/src/pages/home/sub_screens/AfterAdhanHadithSubScreen.dart
@@ -61,11 +61,13 @@ class _AfterAdhanSubScreenState extends State<AfterAdhanSubScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final lang = Localizations.localeOf(context).languageCode;
     return HadithWidget(
       title: arTranslation.afterAdhanHadithTitle,
       arabicText: arTranslation.afterSalahHadith,
       translatedTitle: S.of(context).afterAdhanHadithTitle,
       translatedText: S.of(context).afterSalahHadith,
+      locale:lang,
     );
   }
 }

--- a/lib/src/pages/home/sub_screens/AfterSalahAzkarScreen.dart
+++ b/lib/src/pages/home/sub_screens/AfterSalahAzkarScreen.dart
@@ -73,7 +73,6 @@ class _AfterSalahAzkarState extends State<AfterSalahAzkar> {
   Widget build(BuildContext context) {
     final translatedHadith = translatedItem(activeHadith);
     final arabicHadith = arabicItem(activeHadith);
-
     return Column(
       children: [
         SizedBox(height: 10),
@@ -83,6 +82,7 @@ class _AfterSalahAzkarState extends State<AfterSalahAzkar> {
             title: azkarTitle,
             arabicText: arabicHadith,
             translatedText: translatedHadith,
+            locale: context.watch<MosqueManager>().mosqueConfig!.hadithLang ?? 'en',
           ),
         ),
         ResponsiveMiniSalahBarWidget(),

--- a/lib/src/pages/home/sub_screens/DuaaBetweenAdhanAndIqama.dart
+++ b/lib/src/pages/home/sub_screens/DuaaBetweenAdhanAndIqama.dart
@@ -42,8 +42,10 @@ class _DuaaBetweenAdhanAndIqamaaScreenState
 
   @override
   Widget build(BuildContext context) {
+    // final s = S.of(context);
     return HadithWidget(
       title: 'الدعاء لا يرد بين الأذان والإقامة',
+      locale: context.watch<MosqueManager>().mosqueConfig!.hadithLang ?? 'en',
       arabicText: arabicTr.duaaBetweenSalahAndAdhan,
       translatedText: S.of(context).duaaBetweenSalahAndAdhan,
     );

--- a/lib/src/pages/home/sub_screens/DuaaEftarScreen.dart
+++ b/lib/src/pages/home/sub_screens/DuaaEftarScreen.dart
@@ -37,12 +37,14 @@ class _DuaaEftarScreenState extends State<DuaaEftarScreen> {
   @override
   Widget build(BuildContext context) {
     final arabic = AppLocalizationsAr();
+    final lang = Localizations.localeOf(context).languageCode;
 
     return Column(
       children: [
         AboveSalahBar(),
         Expanded(
           child: HadithWidget(
+            locale: lang,
             title: arabic.duaaElEftar,
             arabicText: arabic.duaaElEftarText,
             translatedText: S.of(context).duaaElEftarText,

--- a/lib/src/pages/home/sub_screens/JumuaHadithSubScreen.dart
+++ b/lib/src/pages/home/sub_screens/JumuaHadithSubScreen.dart
@@ -17,7 +17,7 @@ class JumuaHadithSubScreen extends StatelessWidget {
     final mosqueConfig = context.read<MosqueManager>().mosqueConfig;
     final tr = S.of(context);
     final jumuaArHadith = AppLocalizationsAr().jumuaaHadith;
-
+    final lang = Localizations.localeOf(context).languageCode;
     if (!mosqueConfig!.jumuaDhikrReminderEnabled!) return Scaffold(backgroundColor: Colors.black);
 
     return Column(
@@ -28,6 +28,7 @@ class JumuaHadithSubScreen extends StatelessWidget {
         ),
         Expanded(
           child: HadithWidget(
+            locale: lang,
             title: tr.jumuaaScreenTitle,
             arabicText: jumuaArHadith,
             translatedText: tr.jumuaaHadith,

--- a/lib/src/pages/home/sub_screens/RandomHadithScreen.dart
+++ b/lib/src/pages/home/sub_screens/RandomHadithScreen.dart
@@ -46,6 +46,7 @@ class _RandomHadithScreenState extends State<RandomHadithScreen> {
         Expanded(
           child: HadithWidget(
             translatedText: hadith,
+            locale: context.watch<MosqueManager>().mosqueConfig!.hadithLang ?? 'en',
             textDirection: StringManager.getTextDirectionOfLocal(
               Locale(mosqueManager.mosqueConfig!.hadithLang ?? 'en'),
             ),

--- a/lib/src/pages/home/sub_screens/takberat_aleid_screen.dart
+++ b/lib/src/pages/home/sub_screens/takberat_aleid_screen.dart
@@ -44,6 +44,7 @@ class _TakberatAleidScreenState extends State<TakberatAleidScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final lang = Localizations.localeOf(context).languageCode;
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 10),
       child: Column(
@@ -52,6 +53,7 @@ class _TakberatAleidScreenState extends State<TakberatAleidScreen> {
           Expanded(
             child: HadithWidget(
               title: S.of(context).eidMubarak,
+              locale: lang,
               translatedText: S.of(context).takbeerAleidText,
               mainAxisAlignment: MainAxisAlignment.start,
             ),

--- a/lib/src/pages/home/widgets/HadithScreen.dart
+++ b/lib/src/pages/home/widgets/HadithScreen.dart
@@ -5,10 +5,13 @@ import 'package:mawaqit/src/helpers/RelativeSizes.dart';
 import 'package:mawaqit/src/helpers/repaint_boundaries.dart';
 import 'package:mawaqit/src/themes/UIShadows.dart';
 
+import '../../../helpers/font_manager.dart';
+
 /// this screen made to show of the hadith screen
 class HadithWidget extends StatelessWidget {
   HadithWidget({
     Key? key,
+    required this.locale,
     this.title,
     this.arabicText,
     this.translatedTitle,
@@ -28,6 +31,9 @@ class HadithWidget extends StatelessWidget {
 
   /// translated title of the hadith
   final String? translatedTitle;
+
+  /// locale of the translated text
+  final String locale;
 
   /// translated text of the hadith
   final String? translatedText;
@@ -50,22 +56,26 @@ class HadithWidget extends StatelessWidget {
             titleText(
               title!,
               textDirection: TextDirection.rtl,
+              locale: locale,
             ),
           if (arabicText != null && arabicText != '')
             contentText(
               arabicText!,
               textDirection: TextDirection.rtl,
+              locale: 'ar',
               delay: .1.seconds,
             ),
           if (translatedTitle != null && translatedTitle != title && translatedTitle != '')
             titleText(
               translatedTitle!,
+              locale: locale,
               textDirection: textDirection,
               delay: .2.seconds,
             ),
           if (translatedText != null && translatedText != arabicText && translatedText != '')
             contentText(
               translatedText!,
+              locale: locale,
               textDirection: textDirection,
               delay: .3.seconds,
             ),
@@ -76,6 +86,7 @@ class HadithWidget extends StatelessWidget {
 
   Widget titleText(
     String text, {
+     required  String locale,
     TextDirection? textDirection,
     Duration? delay,
   }) {
@@ -85,7 +96,7 @@ class HadithWidget extends StatelessWidget {
         fontSize: 6.2.vwr,
         fontWeight: FontWeight.bold,
         color: Colors.white,
-        shadows: kAfterAdhanTextShadow,
+        fontFamily: FontManager.getFontFamily(locale ),
       ),
       textAlign: TextAlign.center,
       textDirection: textDirection,
@@ -94,6 +105,7 @@ class HadithWidget extends StatelessWidget {
 
   Widget contentText(
     String text, {
+        required  String locale,
     TextDirection? textDirection,
     Duration? delay,
   }) {
@@ -108,6 +120,7 @@ class HadithWidget extends StatelessWidget {
             text,
             style: TextStyle(
               fontSize: 600,
+              fontFamily: FontManager.getFontFamily(locale),
               color: Colors.white,
               shadows: kIqamaCountDownTextShadow,
             ),


### PR DESCRIPTION
📝 **Summary**
---
- **PR Fix:** #929 
- 
**Detailed Description**
---
- **New Features:**
  - **Locale Parameter in HadithWidget:** Adds localization support for font management.
  - **Font Manager Class:** New class introduced for handling fonts based on locale.
  - **Font Family Handling:** Adjusts contentText and titleText font family in Hadith widget according to locale.
  - **Affected Screens:** Updates applied to screens like AfterAdhanSubScreen, AfterSalahAzkar, and more.

**Tests**
---
- 🧪 **Use case 1:**
  - **Objective:** Verify that the font is applied in `RandomHadithScreen`.
  - **Procedure:** Launch app, open RandomHadithScreen, and observe font changes in HadithWidget.
  - **Visual Proof:**  
<img width="1133" alt="image" src="https://github.com/mawaqit/android-tv-app/assets/70436855/5fd4b4fe-44d6-4765-89e8-9e39baea6eff">


**Checklist**
---
- [x] **Coding Standards:** Code reviewed for adherence to project standards.
- [x] **Testing:** Functionality tested and confirmed as expected.
- [x] **Merge Conflicts:** Resolved conflicts with main/development branch.
- [x] **Branch Status:** Branch aligned with target branch (main/development).