### PR TITLE
952 gray screen when jumua is disabled

### DIFF
--- a/lib/src/models/times.dart
+++ b/lib/src/models/times.dart
@@ -127,9 +127,14 @@ class Times {
   }
 
   factory Times.fromMap(Map<String, dynamic> map) {
+    /// if the jumua is null and jumua2 is not null, we use jumua2 as jumua
+    String? replacedJumua = (map['jumua'] == null && map['jumua2'] != null)
+        ? null
+        : map['jumua2'];
+    print('time: $map');
     return Times(
-      jumua: map['jumua'],
-      jumua2: map['jumua2'],
+      jumua: map['jumua'] ?? map['jumua2'],
+      jumua2: replacedJumua,
       aidPrayerTime: map['aidPrayerTime'],
       aidPrayerTime2: map['aidPrayerTime2'],
       hijriAdjustment: map['hijriAdjustment'] ?? -1,

--- a/lib/src/models/times.dart
+++ b/lib/src/models/times.dart
@@ -131,7 +131,6 @@ class Times {
     String? replacedJumua = (map['jumua'] == null && map['jumua2'] != null)
         ? null
         : map['jumua2'];
-    print('time: $map');
     return Times(
       jumua: map['jumua'] ?? map['jumua2'],
       jumua2: replacedJumua,

--- a/lib/src/services/mixins/mosque_helpers_mixins.dart
+++ b/lib/src/services/mixins/mosque_helpers_mixins.dart
@@ -251,18 +251,18 @@ mixin MosqueHelpersMixin on ChangeNotifier {
     return now.add(Duration(days: (7 - now.weekday + DateTime.friday) % 7));
   }
 
-  /// return next Jumuaa date
-  /// if today is Jumuaa return today jumuaa date
-  /// else return next friday date
+  /// cases 1: if Jumuaa is as Duhr return Duhr pray of the day.
+  /// cases 2: if Jumuaa is not as Duhr and both jumuaa and jumuaa2 are empty return next friday date.
+  /// cases 3: if Jumuaa is not as Duhr and jumuaa or jumuaa2 is not empty return *jumuaa1* time.
   DateTime activeJumuaaDate([DateTime? now]) {
     final nextFriday = nextFridayDate(now);
+    if(times!.jumuaAsDuhr == true) return  timesOfDay(nextFriday)[1].toTimeOfDay()!.toDate(nextFriday);
     bool isJumuaOrJumua2EmptyOrNull = (times?.jumua ?? '').isEmpty && (times?.jumua2 ?? '').isEmpty;
     if (isJumuaOrJumua2EmptyOrNull) {
       return nextFriday;
     }
 
-    final jumuaaTime = times!.jumuaAsDuhr ? timesOfDay(nextFriday)[1] : times!.jumua;
-
+    final jumuaaTime = times!.jumua;
     return jumuaaTime!.toTimeOfDay()!.toDate(nextFriday);
   }
 

--- a/lib/src/services/mixins/mosque_helpers_mixins.dart
+++ b/lib/src/services/mixins/mosque_helpers_mixins.dart
@@ -256,14 +256,17 @@ mixin MosqueHelpersMixin on ChangeNotifier {
   /// cases 3: if Jumuaa is not as Duhr and jumuaa or jumuaa2 is not empty return *jumuaa1* time.
   DateTime activeJumuaaDate([DateTime? now]) {
     final nextFriday = nextFridayDate(now);
-    if(times!.jumuaAsDuhr == true) return  timesOfDay(nextFriday)[1].toTimeOfDay()!.toDate(nextFriday);
-    bool isJumuaOrJumua2EmptyOrNull = (times?.jumua ?? '').isEmpty && (times?.jumua2 ?? '').isEmpty;
-    if (isJumuaOrJumua2EmptyOrNull) {
+    if (times!.jumuaAsDuhr == true) return timesOfDay(nextFriday)[1].toTimeOfDay()!.toDate(nextFriday);
+    if (_isJumuaOrJumua2EmptyOrNull()) {
       return nextFriday;
     }
 
-    final jumuaaTime = times!.jumua;
-    return jumuaaTime!.toTimeOfDay()!.toDate(nextFriday);
+    final jumuaaTime = times!.jumua; // return jumuaa1 time
+    return jumuaaTime!.toTimeOfDay()!.toDate(nextFriday); // parsing the value of juma to time of day and then to date
+  }
+
+  bool _isJumuaOrJumua2EmptyOrNull() {
+    return (times?.jumua ?? '').isEmpty && (times?.jumua2 ?? '').isEmpty;
   }
 
   /// if the iqama is less than 2min

--- a/lib/src/services/mixins/mosque_helpers_mixins.dart
+++ b/lib/src/services/mixins/mosque_helpers_mixins.dart
@@ -256,6 +256,10 @@ mixin MosqueHelpersMixin on ChangeNotifier {
   /// else return next friday date
   DateTime activeJumuaaDate([DateTime? now]) {
     final nextFriday = nextFridayDate(now);
+    bool isJumuaOrJumua2EmptyOrNull = (times?.jumua ?? '').isEmpty && (times?.jumua2 ?? '').isEmpty;
+    if (isJumuaOrJumua2EmptyOrNull) {
+      return nextFriday;
+    }
 
     final jumuaaTime = times!.jumuaAsDuhr ? timesOfDay(nextFriday)[1] : times!.jumua;
 


### PR DESCRIPTION

📝 **Summary**
---
**This PR fixes**  #952

**Description**
---
Resolved an issue where not filling both Juma values and disabling 'Juma as Duhr' resulted in a null exception on Android TV, causing a grey screen. The solution ensures proper handling of null values for Juma times.

**Tests**
---
🧪 **Test Case 1: Juma 1 is null, Juma 2 is not null**
- Description: Validate that the application correctly handles scenarios where Juma 1 is not provided but Juma 2 is.
- Result: 

https://github.com/mawaqit/android-tv-app/assets/70436855/c82f4510-f302-4002-9e88-efd8c4b5b1f0


🧪 **Test Case 2: Juma 1 is not null, Juma 2 is null**
- Description: Ensure that the application operates correctly when Juma 1 is provided, but Juma 2 is not.
- Result: 

https://github.com/mawaqit/android-tv-app/assets/70436855/d2b98db0-aa42-49a3-8bdb-51a6c73997d5


🧪 **Test Case 3: Juma as Duhr**
- Description: Test the functionality when 'Juma as Duhr' is enabled.
- Result: 
- 
https://github.com/mawaqit/android-tv-app/assets/70436855/5bb47eb8-2672-4151-9636-4a8c1d00bafd


🧪 **Test Case 4: Both Juma 1 and Juma 2 are null**
- Description: Check application behavior when both Juma 1 and Juma 2 are not provided.
- Result: 

https://github.com/mawaqit/android-tv-app/assets/70436855/40d7d8dc-80bd-4008-b716-74af3b0f6c67


**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).
