### PR TITLE
fix sentry issue # 951 null check operator used on a null value

### DIFF
--- a/lib/src/pages/home/widgets/workflows/repeating_workflow_widget.dart
+++ b/lib/src/pages/home/widgets/workflows/repeating_workflow_widget.dart
@@ -232,8 +232,9 @@ class _RepeatingWorkFlowWidgetState extends State<RepeatingWorkFlowWidget> {
   @override
   Widget build(BuildContext context) {
     if (activeItem != null) {
-      final item = widget.items[activeItem!];
-      return item.builder(context, () => onItemDone(activeItem!));
+      final localActiveItem = activeItem;
+      final item = widget.items[localActiveItem!];
+      return item.builder(context, () => onItemDone(localActiveItem));
     }
 
     return widget.child ?? Container();


### PR DESCRIPTION
📝 **Summary**
---
**This PR fixes**  #951 

**Description**
---

The issue (Race condition) is related to the asynchronous nature of the code, specifically with the usage of Future.delayed and the setState method. The problem arises when the onItemDone method is called, and it triggers a setState while another asynchronous operation (Future.delayed) is still running. 

Now, if, during this process, the Future.delayed in the original asynchronous operation (e.g., startItem method) is still pending when the rebuild happens, it may cause a conflict. The rebuild might try to access activeItem, which has been set to null by the setState in the onItemDone method. This can result in a Null check operator used on a null value error.

**TL;DR**
In the build method of repeating_workflow_widget.dart file
```Dart
  @override
  Widget build(BuildContext context) {
    if (activeItem != null) {
      final item = widget.items[activeItem!];
      return item.builder(context, () => onItemDone(activeItem!));
    }

    return widget.child ?? Container();
  }
```

1.  When a new workflow starts (e.g., Announcement) it sets an int value to activeItem.
2. This checks our condition ```(activeItem != null)``` then asynchronously activeItem value changes to null while its within the condition scope precisely when onItemDone is called. 
3.  This lead leads us to calling onItemDone(null!) which results in the _TypeError Null check operator used on a null value issue.


🧪 **Solution**
---

- Set a local variable for activeItem within the condition and use that local variable throughout the condition block


💬 **Description:**

By declaring localActiveItem, we create a local copy of activeItem that is specific to that specific block. Changing activeItem later in the block won't affect the value of localActiveItem.

```Dart
  @override
  Widget build(BuildContext context) {
    if (activeItem != null) {
      final localActiveItem = activeItem;
      final item = widget.items[localActiveItem!];
      return item.builder(context, () => onItemDone(localActiveItem));
    }

    return widget.child ?? Container();
  }
```

This can be a useful strategy to prevent unintended changes to activeItem during asynchronous operations or within conditions where its value needs to remain constant. 



**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).
