### PR TITLE
#950 Fix TimeoutException after 0:00:05.000000: Future not completed

### DIFF
--- a/lib/src/helpers/Api.dart
+++ b/lib/src/helpers/Api.dart
@@ -37,6 +37,8 @@ class Api {
   static final dioStatic = Dio(
     BaseOptions(
       baseUrl: kStaticFilesUrl,
+      connectTimeout: Duration(seconds: 5),
+      receiveTimeout: Duration(seconds: 10),
       headers: {
         'Api-Access-Token': kApiToken,
         'accept': 'application/json',
@@ -149,7 +151,8 @@ class Api {
   }
 
   static Future<void> cacheHadithXMLFiles({String language = 'ar'}) =>
-      Future.wait(language.split('-').map((e) => dioStatic.get('/xml/ahadith/$e.xml')));
+      Future.wait(
+          language.split('-').map((e) => dioStatic.get('/xml/ahadith/$e.xml')));
 
   /// get the hadith file from the static server and cache it
   /// return random hadith from the file
@@ -158,7 +161,7 @@ class Api {
     language = (language.split('-')..shuffle()).first;
 
     /// this should be called only on offline mode so it should hit the cache
-    final response = await dioStatic.get('/xml/ahadith/$language.xml').timeout(Duration(seconds: 5));
+    final response = await dioStatic.get('/xml/ahadith/$language.xml');
 
     final document = XmlDocument.from(response.data)!;
 


### PR DESCRIPTION
📝 **Summary**
---
**This PR fixes**  #950 

**Description**
---
The previously implemented behavior featured a 5-second timeout when attempting to retrieve a random cached hadith, triggering an exception if the timeout was exceeded. To address delays in response, the recommended solution involves using connect and receive timeouts for the Dio instance. This require setting a timeout for waiting on the backend's response and specifying a duration for obtaining the particular hadith XML file.


**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).
