### PR TITLE
944 random hadiths are not displayed if the option disable hadith between 2 prayers is enabled

### DIFF
--- a/lib/src/services/mixins/mosque_helpers_mixins.dart
+++ b/lib/src/services/mixins/mosque_helpers_mixins.dart
@@ -40,8 +40,7 @@ mixin MosqueHelpersMixin on ChangeNotifier {
     if (periods == null) {
       return false;
     }
-
-    return salahIndex >= periods.$1 && salahIndex <= periods.$2;
+    return salahIndex >= periods.$1 && salahIndex < periods.$2;
   }
 
   /// Parses the start and end periods from the disabling interval configuration.

--- a/lib/src/services/mixins/mosque_helpers_mixins.dart
+++ b/lib/src/services/mixins/mosque_helpers_mixins.dart
@@ -30,11 +30,36 @@ mixin MosqueHelpersMixin on ChangeNotifier {
         S.current.isha,
       ][index];
 
+  /// Checks if the Hadith feature should be disabled based on the current Salah time.
+  /// The disabling rule is defined in the mosque configuration.
+  ///
+  /// Returns `true` if the Hadith feature is disabled for the current Salah time.
   bool isDisableHadithBetweenSalah() {
-    final disableTime = mosqueConfig?.randomHadithIntervalDisabling ?? '';
-    final disabledHadithPeriod = int.tryParse(disableTime.split('-').first);
+    (int, int)? periods = _parseDisablingPeriods(mosqueConfig?.randomHadithIntervalDisabling ?? '');
 
-    return disabledHadithPeriod == salahIndex;
+    if (periods == null) {
+      return false;
+    }
+
+    return salahIndex >= periods.$1 && salahIndex <= periods.$2;
+  }
+
+  /// Parses the start and end periods from the disabling interval configuration.
+  /// Returns a `tuple` containing the start and end periods, or `null` if parsing fails.
+  (int, int)? _parseDisablingPeriods(String config) {
+    if (!config.contains('-')) {
+      return null;
+    }
+
+    List<String> parts = config.split('-');
+    int? startPeriod = int.tryParse(parts[0]);
+    int? endPeriod = int.tryParse(parts[1]);
+
+    if (startPeriod == null || endPeriod == null) {
+      return null;
+    }
+
+    return (startPeriod, endPeriod);
   }
 
   bool adhanVoiceEnable([int? salahIndex]) {


### PR DESCRIPTION

📝 **Summary**
This PR refactors the `isDisableHadithBetweenSalah` method in the `MosqueHelpersMixin` class. The method's functionality has been expanded to handle a range of disabled periods rather than a single period. Additionally, the method's readability have been improved by breaking down its logic into more manageable parts.

**This PR for issue**  #944 

💬 **Description:**
- Implemented `_parseDisablingPeriods` private method to extract the logic for parsing the start and end periods of the disabling interval.
- Updated `isHadithDisabledDuringSalah` method to use the parsed start and end periods for determining if the Hadith feature is disabled.
- Handle the null values that might occur after parsing. 

**Issue Solved**
The original implementation of `isDisableHadithBetweenSalah` only considered a single period for disabling the Hadith feature, which limited its functionality. This update addresses these issues by:

1. **Extending Functionality**: The method now correctly handles a range of periods during which the Hadith feature should be disabled, as defined in the mosque configuration.

📷 **Screenshots or GIFs (if applicable):**

### First test case:
---

Setup the Disable hadiths between Asr and Maghrib and test. When the current time is between Fajr and Duhr prayers 

<img width="1099" alt="image" src="https://github.com/mawaqit/android-tv-app/assets/70436855/dd8907f9-7bc1-4f9d-aa7a-9b065f520e9e">

https://github.com/mawaqit/android-tv-app/assets/70436855/f05e5654-ad98-4ff4-8d08-e6af4ff8de0c

### Second test case:
---

Setup the Disable hadiths between Asr and Maghrib and test. When the current time is between Maghrib and Isha prayers 

<img width="1099" alt="image" src="https://github.com/mawaqit/android-tv-app/assets/70436855/dd8907f9-7bc1-4f9d-aa7a-9b065f520e9e">

https://github.com/mawaqit/android-tv-app/assets/70436855/50b691cf-0246-4629-a440-a50121d66ed1

### Third test case:
---

Setup the Disable hadiths between Asr and Maghrib and test. When the current time is between Asr and Maghrib prayers 

<img width="1099" alt="image" src="https://github.com/mawaqit/android-tv-app/assets/70436855/dd8907f9-7bc1-4f9d-aa7a-9b065f520e9e">

![2023-12-29 20-50-42](https://github.com/mawaqit/android-tv-app/assets/70436855/95cc392b-2082-41c2-898c-744ed0b2332b)

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).
