### PR TITLE
Fix check connectivity

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,7 +2,8 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart' show ProviderScope;
+import 'package:flutter_riverpod/flutter_riverpod.dart'
+    show ProviderBase, ProviderContainer, ProviderObserver, ProviderScope;
 import 'package:logger/logger.dart';
 import 'package:mawaqit/i18n/AppLanguage.dart';
 import 'package:mawaqit/i18n/l10n.dart';
@@ -13,6 +14,7 @@ import 'package:mawaqit/src/helpers/Api.dart';
 import 'package:mawaqit/src/helpers/AppRouter.dart';
 import 'package:mawaqit/src/helpers/ConnectivityService.dart';
 import 'package:mawaqit/src/helpers/CrashlyticsWrapper.dart';
+import 'package:mawaqit/src/helpers/riverpod_logger.dart';
 import 'package:mawaqit/src/pages/SplashScreen.dart';
 import 'package:mawaqit/src/services/audio_manager.dart';
 import 'package:mawaqit/src/services/mosque_manager.dart';
@@ -29,7 +31,12 @@ Future<void> main() async {
     () async {
       WidgetsFlutterBinding.ensureInitialized();
       await Firebase.initializeApp();
-      runApp(ProviderScope(child: MyApp()));
+      runApp(
+        ProviderScope(
+          child: MyApp(),
+          observers: [RiverpodLogger()],
+        ),
+      );
     },
   );
 }

--- a/lib/src/helpers/connectivity_provider.dart
+++ b/lib/src/helpers/connectivity_provider.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/address_model.dart';
+import '../services/connectivity_service.dart';
+
+/// This class listens to connectivity changes and notifies its listeners.
+class ConnectivityProvider extends StreamNotifier<ConnectivityStatus> {
+
+  /// Overriding the [build] method to define how the stream of connectivity status is created.
+  /// default time for checking connection is 2 seconds.
+  @override
+  Stream<ConnectivityStatus> build() {
+    return ref
+        .watch(connectivityServiceProvider(ConnectivityServiceParams(
+          interval: const Duration(seconds: 2),
+        )))
+        .onStatusChange;
+  }
+}
+/// Global provider for [ConnectivityProvider].
+/// This provider allows access to the connectivity status stream from anywhere in the app.
+final connectivityProvider =
+StreamNotifierProvider<ConnectivityProvider, ConnectivityStatus>(ConnectivityProvider.new);

--- a/lib/src/helpers/connectivity_provider.dart
+++ b/lib/src/helpers/connectivity_provider.dart
@@ -12,7 +12,7 @@ class ConnectivityProvider extends StreamNotifier<ConnectivityStatus> {
   Stream<ConnectivityStatus> build() {
     return ref
         .watch(connectivityServiceProvider(ConnectivityServiceParams(
-          interval: const Duration(seconds: 2),
+          interval: const Duration(seconds: 10),
         )))
         .onStatusChange;
   }

--- a/lib/src/helpers/riverpod_logger.dart
+++ b/lib/src/helpers/riverpod_logger.dart
@@ -1,0 +1,21 @@
+import 'dart:developer';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class RiverpodLogger extends ProviderObserver {
+  @override
+  void didUpdateProvider(
+    ProviderBase<Object?> provider,
+    Object? previousValue,
+    Object? newValue,
+    ProviderContainer container,
+  ) {
+    log('''
+       {
+          "provider": "${provider.name ?? provider.runtimeType}",
+          "newValue": "$newValue",
+          "previousValue": "$previousValue",
+       }
+    ''');
+  }
+}

--- a/lib/src/models/address_model.dart
+++ b/lib/src/models/address_model.dart
@@ -1,0 +1,28 @@
+import 'dart:io';
+
+enum ConnectivityStatus {
+  disconnected,
+  connected,
+}
+
+class AddressCheckOptions {
+  final InternetAddress address;
+
+  AddressCheckOptions(this.address);
+
+  @override
+  String toString() => "AddressCheckOptions($address)";
+}
+
+class AddressCheckResult {
+  final AddressCheckOptions options;
+  final bool isSuccess;
+
+  AddressCheckResult(
+    this.options,
+    this.isSuccess,
+  );
+
+  @override
+  String toString() => "AddressCheckResult($options, $isSuccess)";
+}

--- a/lib/src/pages/home/widgets/offline_widget.dart
+++ b/lib/src/pages/home/widgets/offline_widget.dart
@@ -1,29 +1,33 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mawaqit/i18n/l10n.dart';
 import 'package:mawaqit/src/helpers/RelativeSizes.dart';
+import 'package:mawaqit/src/models/address_model.dart';
 import 'package:mawaqit/src/services/mosque_manager.dart';
 import 'package:mawaqit/src/themes/UIShadows.dart';
 import 'package:provider/provider.dart';
 
-class OfflineWidget extends StatelessWidget {
+import '../../../helpers/connectivity_provider.dart';
+class OfflineWidget extends ConsumerWidget {
   const OfflineWidget({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final mosqueManager = context.read<MosqueManager>();
     final tr = S.of(context);
-
-    return Row(
+    final connectivity = ref.watch(connectivityProvider);
+    return switch(connectivity){
+      AsyncData(:final value) => Row(
         mainAxisSize: MainAxisSize.min,
         children: [
           SizedBox(width: 1.vw),
           CircleAvatar(
             radius: .4.vwr,
-            backgroundColor: mosqueManager.isOnline ? Colors.green : Colors.red[700],
+            backgroundColor: value == ConnectivityStatus.connected ? Colors.green : Colors.red[700],
           ),
           SizedBox(width: .4.vwr),
           Text(
-            mosqueManager.isOnline ? tr.online : tr.offline,
+            value == ConnectivityStatus.connected ? tr.online : tr.offline,
             style: TextStyle(
               color: Colors.white,
               shadows: kHomeTextShadow,
@@ -33,6 +37,9 @@ class OfflineWidget extends StatelessWidget {
             ),
           ),
         ],
-      );
+      ),
+      AsyncError(:final error) => Container(),
+      _ => const CircularProgressIndicator(),
+    };
   }
 }

--- a/lib/src/services/connectivity_service.dart
+++ b/lib/src/services/connectivity_service.dart
@@ -1,0 +1,156 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/address_model.dart';
+
+/// [ConnectivityService] is responsible for checking the network connectivity status.
+/// It performs checks against a list of specified internet addresses.
+class ConnectivityService {
+  /// Default port to check connection.
+  final int defaultPort = 53;
+
+  /// Default timeout to check connection.
+  final Duration defaultTimeout;
+
+  /// Default interval to recheck connection status.
+  final Duration defaultInterval;
+
+  /// Default addresses to test against.
+  final List<AddressCheckOptions> defaultAddresses = List<AddressCheckOptions>.unmodifiable(
+    <AddressCheckOptions>[
+      AddressCheckOptions(
+        InternetAddress(
+          '2606:4700:4700::1111', // CloudFlare
+          type: InternetAddressType.IPv6,
+        ),
+      ),
+      AddressCheckOptions(
+        InternetAddress(
+          '8.8.4.4', // Google
+          type: InternetAddressType.IPv4,
+        ),
+      ),
+      AddressCheckOptions(
+        InternetAddress(
+          '2001:4860:4860::8888', // Google
+          type: InternetAddressType.IPv6,
+        ),
+      ),
+    ],
+  );
+
+  ConnectivityService({
+    Duration? interval,
+    Duration? defaultTimeout,
+  })  : defaultInterval = interval ?? const Duration(seconds: 3),
+        defaultTimeout = defaultTimeout ?? const Duration(seconds: 1) {
+    _statusController.onListen = () {
+      _maybeEmitStatusUpdate();
+    };
+    _statusController.onCancel = () {
+      _timerHandle?.cancel();
+      _lastStatus = null; // reset last status
+    };
+  }
+  /// [isHostReachable] returns a [Future] that completes with a [AddressCheckResult] object.
+  /// [isHostReachable] Method to check if a specific host is reachable.
+  Future<AddressCheckResult> isHostReachable(
+    AddressCheckOptions options,
+  ) async {
+    Socket? sock;
+    try {
+      sock = await Socket.connect(
+        options.address,
+        defaultPort,
+        timeout: defaultTimeout,
+      );
+      sock.destroy();
+      return AddressCheckResult(options, true);
+    } catch (e) {
+      sock?.destroy();
+      return AddressCheckResult(options, false);
+    }
+  }
+
+  /// [hasConnection] returns a [Future] that completes with a [bool] object.
+  /// [hasConnection] Method to check if the default addresses are reachable.
+  Future<bool> get hasConnection async {
+    final Completer<bool> result = Completer<bool>();
+    int length = defaultAddresses.length;
+
+    for (final AddressCheckOptions addressOptions in defaultAddresses) {
+      isHostReachable(addressOptions).then(
+        (AddressCheckResult request) {
+          length -= 1;
+          if (!result.isCompleted) {
+            if (request.isSuccess) {
+              result.complete(true);
+            } else if (length == 0) {
+              result.complete(false);
+            }
+          }
+        },
+      );
+    }
+    return result.future;
+  }
+
+  /// [connectionStatus] returns a [Future] that completes with a [ConnectivityStatus] object.
+  /// [connectionStatus] Method to check the current connectivity status.
+  Future<ConnectivityStatus> get connectionStatus async {
+    return await hasConnection ? ConnectivityStatus.connected : ConnectivityStatus.disconnected;
+  }
+  /// [_maybeEmitStatusUpdate]
+  Future<void> _maybeEmitStatusUpdate([Timer? timer]) async {
+    _timerHandle?.cancel();
+    timer?.cancel();
+    final ConnectivityStatus currentStatus = await connectionStatus;
+
+    if (_lastStatus != currentStatus && _statusController.hasListener) {
+      _statusController.add(currentStatus);
+    }
+
+    if (!_statusController.hasListener) return;
+    _timerHandle = Timer(defaultInterval, _maybeEmitStatusUpdate);
+
+    _lastStatus = currentStatus;
+  }
+
+  ConnectivityStatus? _lastStatus;
+  Timer? _timerHandle;
+
+  final StreamController<ConnectivityStatus> _statusController = StreamController.broadcast();
+
+  Stream<ConnectivityStatus> get onStatusChange => _statusController.stream;
+
+  bool get hasListeners => _statusController.hasListener;
+
+  bool get isActivelyChecking => _statusController.hasListener;
+}
+
+/// Singleton instance of [ConnectivityService] using Riverpod.
+final connectivityServiceProvider =
+Provider.family<ConnectivityService, ConnectivityServiceParams>((
+  ref,
+  params,
+) {
+  final ConnectivityService service = ConnectivityService(
+    interval: params.interval,
+    defaultTimeout: params.timeout,
+  );
+  return service;
+});
+
+/// [AddressCheckOptions] is a class that holds the address to check against.
+class ConnectivityServiceParams {
+  final Duration interval;
+  final Duration timeout;
+
+  const ConnectivityServiceParams({
+    Duration? interval,
+    Duration? timeout,
+  })  : interval = interval ?? const Duration(seconds: 3),
+        timeout = timeout ?? const Duration(seconds: 1);
+}


### PR DESCRIPTION
📝 **Summary**
---
**This PR for issue**: Implement Internet connectivity. 

**Description**
---
This Pull Request introduces a`ConnectivityService` for monitoring network connectivity. it introduces Riverpod package for dependable state management and includes classes such as `ConnectivityProvider`, `AddressCheckOptions`, and `AddressCheckResult`. The service is designed to check against a list of specified internet addresses every **3 seconds** to determine the connectivity status. This feature is crucial for applications that rely on a consistent and reliable internet connection.

**Tests**
---
🧪 **Use case 1**
---
💬 **Description:** Testing connectivity to predefined addresses (Google and CloudFlare) using `ConnectivityService`.
 
📷 **Screenshots or GIFs (if applicable):** _Screenshots of the app successfully determining the connectivity status._

![2024-01-05 11-30-37](https://github.com/mawaqit/android-tv-app/assets/70436855/a6088e31-01bb-4493-9886-896f32c7cd88)

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).