### PR TITLE
refactor(ui): center the `buildMosqueName` in `mosque_header`

### DIFF
--- a/lib/src/pages/home/widgets/mosque_header.dart
+++ b/lib/src/pages/home/widgets/mosque_header.dart
@@ -12,6 +12,8 @@ import 'package:provider/provider.dart';
 import 'package:sizer/sizer.dart';
 import 'package:text_scroll/text_scroll.dart';
 
+import '../../../models/mosqueConfig.dart';
+
 class MosqueHeader extends StatelessOrientationWidget {
   const MosqueHeader({Key? key, required this.mosque}) : super(key: key);
 
@@ -20,68 +22,25 @@ class MosqueHeader extends StatelessOrientationWidget {
   @override
   Widget buildLandscape(BuildContext context) {
     final mosqueConfig = context.watch<MosqueManager>().mosqueConfig;
-
     return Padding(
       padding: EdgeInsets.only(top: 1.8.vh, right: .8.vw),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          OfflineWidget(),
+          Expanded(flex: 2, child: OfflineWidget()),
           Expanded(
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                mosque.logo != null && mosqueConfig!.showLogo
-                    ? Padding(
-                        padding: const EdgeInsets.all(8.0),
-                        child: MawaqitNetworkImage(
-                          imageUrl: mosque.logo!,
-                          width: 40,
-                          height: 40,
-                          errorBuilder: (context, error, stackTrace) => SizedBox(),
-                        ),
-                      )
-                    : SizedBox(),
-                // SizedBox(width: 10),
-                Flexible(
-                  child: Container(
-                    padding: EdgeInsets.only(left: 1.vw),
-                    child: StatefulBuilder(
-                      key: ValueKey(mosque.name.hashCode ^ SizerUtil.orientation.hashCode),
-                      builder: (context, setState) => TextScroll(
-                        mosque.name,
-                        intervalSpaces: 10,
-                        pauseBetween: 3.seconds,
-                        style: TextStyle(
-                          color: Colors.white,
-                          fontSize: 4.vwr,
-                          height: 1.2,
-                          shadows: kIqamaCountDownTextShadow,
-                          fontWeight: FontWeight.bold,
-                          // fontFamily: StringManager.fontFamilyKufi,
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
-
-                // SizedBox(width: 10),
-                mosque.logo != null && mosqueConfig!.showLogo
-                    ? Padding(
-                        padding: const EdgeInsets.all(8.0),
-                        child: MawaqitNetworkImage(
-                          imageUrl: mosque.logo!,
-                          width: 40,
-                          height: 40,
-                          errorBuilder: (context, error, stackTrace) => SizedBox(),
-                        ),
-                      )
-                    : SizedBox(),
-              ],
+            flex: 4,
+            child: buildMosqueName(mosqueConfig),
+          ),
+          Expanded(
+            flex: 2,
+            child: Align(
+              // align based on direction of the text
+              alignment: AlignmentDirectional.centerEnd,
+              child: WeatherWidget(),
             ),
           ),
-          WeatherWidget(),
         ],
       ),
     );
@@ -145,6 +104,62 @@ class MosqueHeader extends StatelessOrientationWidget {
             ],
           ),
           SizedBox(height: 1.8.vh),
+        ],
+      ),
+    );
+  }
+  Container buildMosqueName(MosqueConfig? mosqueConfig){
+    return Container(
+      alignment: Alignment.bottomCenter,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          mosque.logo != null && mosqueConfig!.showLogo
+              ? Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: MawaqitNetworkImage(
+              imageUrl: mosque.logo!,
+              width: 40,
+              height: 40,
+              errorBuilder: (context, error, stackTrace) => SizedBox(),
+            ),
+          )
+              : SizedBox(),
+          // SizedBox(width: 10),
+          Flexible(
+            child: Container(
+              padding: EdgeInsets.only(left: 1.vw),
+              child: StatefulBuilder(
+                key: ValueKey(mosque.name.hashCode ^ SizerUtil.orientation.hashCode),
+                builder: (context, setState) => TextScroll(
+                  mosque.name,
+                  intervalSpaces: 10,
+                  pauseBetween: 3.seconds,
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 4.vwr,
+                    height: 1.2,
+                    shadows: kIqamaCountDownTextShadow,
+                    fontWeight: FontWeight.bold,
+                    // fontFamily: StringManager.fontFamilyKufi,
+                  ),
+                ),
+              ),
+            ),
+          ),
+
+          // SizedBox(width: 10),
+          mosque.logo != null && mosqueConfig!.showLogo
+              ? Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: MawaqitNetworkImage(
+              imageUrl: mosque.logo!,
+              width: 40,
+              height: 40,
+              errorBuilder: (context, error, stackTrace) => SizedBox(),
+            ),
+          )
+              : SizedBox(),
         ],
       ),
     );

--- a/lib/src/pages/times/normal_home/landscape_normal_home.dart
+++ b/lib/src/pages/times/normal_home/landscape_normal_home.dart
@@ -58,6 +58,7 @@ class LandscapeNormalHome extends StatelessWidget {
           child: Row(
             children: [
               Expanded(
+                flex: 2,
                 child: Center(
                   child: FadeInOutWidget(
                     duration: Duration(seconds: 15),
@@ -80,14 +81,14 @@ class LandscapeNormalHome extends StatelessWidget {
                 ),
               ),
               Expanded(
-                  child: HomeTimeWidget().animate().fadeIn().slideY(begin: -1),
-                  flex: 2),
+
+
+                  child: HomeTimeWidget().animate().fadeIn().slideY(begin: -1), flex: 4),
               Expanded(
-                  child: Center(
-                      child: JumuaWidget()
-                          .animate(delay: Duration(milliseconds: 500))
-                          .slideX(begin: 1)
-                          .fadeIn())),
+                flex: 2,
+                child:
+                    Center(child: JumuaWidget().animate(delay: Duration(milliseconds: 500)).slideX(begin: 1).fadeIn()),
+              ),
             ],
           ),
         ),
@@ -104,10 +105,8 @@ class LandscapeNormalHome extends StatelessWidget {
                     iqama: iqamas[i],
                     withDivider: false,
                     showIqama: iqamaEnabled,
-                    active: nextActiveSalah == i &&
-                        (i != 1 ||
-                            !AppDateTime.isFriday ||
-                            mosqueManager.times?.jumua == null),
+                    active:
+                        nextActiveSalah == i && (i != 1 || !AppDateTime.isFriday || mosqueManager.times?.jumua == null),
                     isIqamaMoreImportant: isIqamaMoreImportant,
                   ),
               ]

--- a/lib/src/pages/times/turkish_home/landscape_turkish_home.dart
+++ b/lib/src/pages/times/turkish_home/landscape_turkish_home.dart
@@ -45,7 +45,7 @@ class LandScapeTurkishHome extends StatelessWidget {
 
     final nextActiveSalah = mosqueManager.nextSalahIndex();
 
-    return Column( 
+    return Column(
       children: [
         MosqueHeader(mosque: mosqueManager.mosque!),
         Expanded(
@@ -53,6 +53,7 @@ class LandScapeTurkishHome extends StatelessWidget {
           child: Row(
             children: [
               Expanded(
+                flex: 2,
                 child: Center(
                   child: SalahItemWidget(
                     title: S.of(context).sabah,
@@ -66,8 +67,8 @@ class LandScapeTurkishHome extends StatelessWidget {
                   ).animate().slideX().fade(),
                 ),
               ),
-              Expanded(child: HomeTimeWidget().animate().slideY().fade(), flex: 2), 
-              Expanded(child: Center(child: JumuaWidget().animate().slideX(begin: 1).fade())),
+              Expanded(flex: 4, child: HomeTimeWidget().animate().slideY().fade()),
+              Expanded(flex: 2, child: Center(child: JumuaWidget().animate().slideX(begin: 1).fade())),
             ],
           ),
         ),


### PR DESCRIPTION
📝 **Summary**
---
**This PR for issue #915**

**Description**
---
This pull request addresses issue #915, which involves centering the header that displays the name of the mosque on the home screen of the mosque. The modification ensures that the header is properly aligned in both LTR and RTL languages.

**Tests**
---
🧪 **Use case 1: English Language Header**
---
💬 **Description:**
Tested the header alignment on the homepage in English. The header is now centered correctly and maintains its position across different screen sizes and devices.

📷 **Screenshots or GIFs (if applicable):**

<img width="1147" alt="image" src="https://github.com/mawaqit/android-tv-app/assets/70436855/075cdba6-0181-4bea-a0fb-a4d97fa23165">

🧪 **Use case 2: Arabic Language Header**
---
💬 **Description:**
Evaluated the header alignment in the Arabic version of the homepage. The RTL (Right-to-Left) layout is correctly handled, and the header remains centered and consistent.

📷 **Screenshots or GIFs (if applicable):**

<img width="976" alt="image" src="https://github.com/mawaqit/android-tv-app/assets/70436855/e8d380f6-3b23-44ee-9835-e90ad11bf02f">

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes in both English and Arabic languages, and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).
