### PR TITLE
Fix #1001 change access method to tap on the version number

### DIFF
--- a/lib/src/pages/AboutScreen.dart
+++ b/lib/src/pages/AboutScreen.dart
@@ -1,47 +1,17 @@
-import 'package:easy_debounce/easy_debounce.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:mawaqit/const/resource.dart';
 import 'package:mawaqit/src/pages/onBoarding/widgets/MawaqitAboutWidget.dart';
-import 'package:mawaqit/src/services/user_preferences_manager.dart';
 import 'package:mawaqit/src/widgets/ScreenWithAnimation.dart';
-import 'package:provider/provider.dart';
 
 class AboutScreen extends StatelessWidget {
   const AboutScreen({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    int tapCount = 0;
-    return Focus(
-      onKeyEvent: (node, event) {
-        if (event.logicalKey != LogicalKeyboardKey.arrowDown) return KeyEventResult.ignored;
-
-        tapCount++;
-        if (tapCount >= 7) {
-          context.read<UserPreferencesManager>().developerModeEnabled = true;
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content:
-                  Text("You have activated the Abogabal secret menu 😎💪 رائع! لقد قمت بتنشيط قائمة أبو جبل السرية"),
-            ),
-          );
-          tapCount = -100;
-          return KeyEventResult.handled;
-        }
-
-        EasyDebounce.debounce('tag', Duration(milliseconds: 2000), () {
-          tapCount = 0;
-        });
-        return KeyEventResult.handled;
-      },
-      canRequestFocus: true,
-      autofocus: true,
-      child: Scaffold(
-        body: ScreenWithAnimationWidget(
-          animation: R.ASSETS_ANIMATIONS_LOTTIE_WELCOME_JSON,
-          child: OnBoardingMawaqitAboutWidget(),
-        ),
+    return Scaffold(
+      body: ScreenWithAnimationWidget(
+        animation: R.ASSETS_ANIMATIONS_LOTTIE_WELCOME_JSON,
+        child: OnBoardingMawaqitAboutWidget(),
       ),
     );
   }

--- a/lib/src/widgets/InfoWidget.dart
+++ b/lib/src/widgets/InfoWidget.dart
@@ -1,20 +1,47 @@
 import 'package:flutter/material.dart';
 import 'package:package_info_plus/package_info_plus.dart';
+import 'package:provider/provider.dart';
 
-class VersionWidget extends StatelessWidget {
+import '../services/user_preferences_manager.dart';
+
+class VersionWidget extends StatefulWidget {
   const VersionWidget({Key? key, this.style, this.textAlign}) : super(key: key);
 
   final TextStyle? style;
   final TextAlign? textAlign;
 
   @override
+  _VersionWidgetState createState() => _VersionWidgetState();
+}
+
+class _VersionWidgetState extends State<VersionWidget> {
+  int tapCount = 0;
+
+  @override
   Widget build(BuildContext context) {
-    return FutureBuilder<PackageInfo>(
-      future: PackageInfo.fromPlatform(),
-      builder: (context, snapshot) => Text(
-        "v${snapshot.data?.version.replaceAll('-tv', '')}-${snapshot.data?.buildNumber}",
-        style: style,
-        textAlign: textAlign,
+    return GestureDetector(
+      onTap: () {
+        setState(() {
+          tapCount++;
+          if (tapCount >= 7) {
+            context.read<UserPreferencesManager>().developerModeEnabled = true;
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(
+                    "You have activated the Abogabal secret menu 😎💪 رائع! لقد قمت بتنشيط قائمة أبو جبل السرية"),
+              ),
+            );
+            tapCount = -100; // Reset tapCount to prevent further triggering
+          }
+        });
+      },
+      child: FutureBuilder<PackageInfo>(
+        future: PackageInfo.fromPlatform(),
+        builder: (context, snapshot) => Text(
+          "v${snapshot.data?.version.replaceAll('-tv', '')}-${snapshot.data?.buildNumber}",
+          style: widget.style,
+          textAlign: widget.textAlign,
+        ),
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -122,7 +122,7 @@ dev_dependencies:
 # following page: https://dart.dev/tools/pub/pubspec
 
 dependency_overrides:
-  win32: ^5.0.5
+  win32: 5.0.5
 
 # The following section is specific to Flutter.
 flutter:


### PR DESCRIPTION
📝 **Summary**
---
**This PR fixes**  #1001 

**Description**
---
To access the debug menu, simply tap the version number seven times instead of navigating to the about menu and tapping the down arrow 7 times. 

**Tests**
---
🧪 **Use case 1**
---
💬 **Description:**

Launch the app and tap the version number 7 times.
 
📷 **Screenshots or GIFs (if applicable):**



https://github.com/mawaqit/android-tv-app/assets/35707318/eb5fbf86-3774-447e-8759-e78551023a1a








**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).
