### PR TITLE
Feat #1001 Add disable debug menu

### DIFF
--- a/lib/src/widgets/InfoWidget.dart
+++ b/lib/src/widgets/InfoWidget.dart
@@ -20,21 +20,35 @@ class _VersionWidgetState extends State<VersionWidget> {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: () {
+onTap: () {
         setState(() {
-          tapCount++;
-          if (tapCount >= 7) {
-            context.read<UserPreferencesManager>().developerModeEnabled = true;
+          if (context.read<UserPreferencesManager>().developerModeEnabled) {
+            // Deactivate debug menu
+            context.read<UserPreferencesManager>().developerModeEnabled = false;
             ScaffoldMessenger.of(context).showSnackBar(
               SnackBar(
                 content: Text(
-                    "You have activated the Abogabal secret menu 😎💪 رائع! لقد قمت بتنشيط قائمة أبو جبل السرية"),
+                    "You have desactivated the Abogabal secret menu 😎💪 رائع! لقد قمت بإلغاء تنشيط قائمة أبو جبل السرية"),
               ),
             );
-            tapCount = -100; // Reset tapCount to prevent further triggering
+          } else {
+            tapCount++;
+            if (tapCount >= 7) {
+              context.read<UserPreferencesManager>().developerModeEnabled =
+                  true;
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text(
+                    "You have activated the Abogabal secret menu 😎💪 رائع! لقد قمت بتنشيط قائمة أبو جبل السرية",
+                  ),
+                ),
+              );
+              tapCount = 0; // Reset tapCount after activation
+            }
           }
         });
       },
+
       child: FutureBuilder<PackageInfo>(
         future: PackageInfo.fromPlatform(),
         builder: (context, snapshot) => Text(


### PR DESCRIPTION
📝 **Summary**
---
**This PR fixes**  #1001 

**Description**
---
To disable the debug menu, simply tap the version number one time. 

**Tests**
---
🧪 **Use case 1**
---
💬 **Description:**

Launch the app and tap the version number 7 times to activate the debug menu then tap one time to disable it.
 
📷 **Screenshots or GIFs (if applicable):**



[disableDebugMenu.webm](https://github.com/mawaqit/android-tv-app/assets/35707318/73e803cd-2da1-4bda-9e3b-2819197500fb)








**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).
