### PR TITLE
Feat: add back button in the settings screen for better user experience  

### DIFF
--- a/lib/src/widgets/ScreenWithAnimation.dart
+++ b/lib/src/widgets/ScreenWithAnimation.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:lottie/lottie.dart';
 import 'package:mawaqit/src/services/user_preferences_manager.dart';
 import 'package:provider/provider.dart';
+import 'package:sizer/sizer.dart';
 
 /// this widget is used to show a screen with a lottie animation on the left side
 class ScreenWithAnimationWidget extends StatelessWidget {
@@ -22,6 +23,18 @@ class ScreenWithAnimationWidget extends StatelessWidget {
     final userPrefs = context.watch<UserPreferencesManager>();
 
     return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back), // Set your desired size here
+          iconSize: 12.sp,
+          splashRadius: 7.sp,
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+        ),
+      ),
       body: SafeArea(
         child: Flex(
           direction: userPrefs.calculatedOrientation == Orientation.portrait ? Axis.vertical : Axis.horizontal,


### PR DESCRIPTION
📝 **Summary**
---
This PR introduces an enhancement in the UX with back button by customizing its size and the splash effect radius, improving the app's responsiveness and user interaction experience across various device sizes.

**This PR is for issue:**  #1006 

**Description**
---
- Add a back button in the AppBar for better visibility and interaction.
- Reduced the splash radius of the back button to decrease the shadow effect when pressed.

**Tests**
---
🧪 **Use case 1**
---
💬 **Description:**
Ensure the back button is appropriately sized and the splash effect across different device sizes, maintaining a consistent and user-friendly interface.

📷 **Screenshots or GIFs (if applicable):**

https://github.com/mawaqit/android-tv-app/assets/70436855/fd8561f8-7961-4277-82ce-9c8f538c9f3b

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected, ensuring the back button's size and splash effect are responsive and consistent across various screen sizes.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).
