### PR TITLE
Fix refactor debug menu access

### DIFF
--- a/lib/src/pages/AboutScreen.dart
+++ b/lib/src/pages/AboutScreen.dart
@@ -1,17 +1,58 @@
 import 'package:flutter/material.dart';
-import 'package:mawaqit/const/resource.dart';
-import 'package:mawaqit/src/pages/onBoarding/widgets/MawaqitAboutWidget.dart';
+import 'package:flutter/services.dart';
+import 'package:provider/provider.dart';
+import 'package:mawaqit/src/services/user_preferences_manager.dart';
 import 'package:mawaqit/src/widgets/ScreenWithAnimation.dart';
+import 'package:mawaqit/src/pages/onBoarding/widgets/MawaqitAboutWidget.dart';
+import 'package:mawaqit/const/resource.dart';
 
 class AboutScreen extends StatelessWidget {
   const AboutScreen({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: ScreenWithAnimationWidget(
-        animation: R.ASSETS_ANIMATIONS_LOTTIE_WELCOME_JSON,
-        child: OnBoardingMawaqitAboutWidget(),
+    int tapCount = 0;
+    bool menuActivated =
+        Provider.of<UserPreferencesManager>(context, listen: false)
+            .developerModeEnabled;
+
+    return RawKeyboardListener(
+      focusNode: FocusNode(),
+      onKey: (RawKeyEvent event) {
+        if (event.logicalKey == LogicalKeyboardKey.arrowDown &&
+            event is RawKeyDownEvent) {
+          if (!menuActivated) {
+            tapCount++;
+            if (tapCount >= 7) {
+              menuActivated = true;
+              Provider.of<UserPreferencesManager>(context, listen: false)
+                  .developerModeEnabled = true;
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text(
+                      "You have activated the Abogabal secret menu 😎💪 رائع! لقد قمت بتنشيط قائمة أبو جبل السرية"),
+                ),
+              );
+              tapCount = 0;
+            }
+          } else {
+            menuActivated = false;
+            Provider.of<UserPreferencesManager>(context, listen: false)
+                .developerModeEnabled = false;
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(
+                    "You have deactivated the Abogabal secret menu 😎💪 رائع! لقد قمت بإلغاء تنشيط قائمة أبو جبل السرية"),
+              ),
+            );
+          }
+        }
+      },
+      child: Scaffold(
+        body: ScreenWithAnimationWidget(
+          animation: R.ASSETS_ANIMATIONS_LOTTIE_WELCOME_JSON,
+          child: OnBoardingMawaqitAboutWidget(),
+        ),
       ),
     );
   }

--- a/lib/src/pages/AboutScreen.dart
+++ b/lib/src/pages/AboutScreen.dart
@@ -8,6 +8,16 @@ import 'package:mawaqit/const/resource.dart';
 
 class AboutScreen extends StatelessWidget {
   const AboutScreen({Key? key}) : super(key: key);
+  static const int _activationTapCount = 7;
+  static const String _activationMessage =
+      "You have activated the Abogabal secret menu 😎💪 رائع! لقد قمت بتنشيط قائمة أبو جبل السرية";
+  static const String _deactivationMessage =
+      "You have deactivated the Abogabal secret menu 😎💪 رائع! لقد قمت بإلغاء تنشيط قائمة أبو جبل السرية";
+  void _showSnackBar(BuildContext context, String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -23,28 +33,18 @@ class AboutScreen extends StatelessWidget {
             event is RawKeyDownEvent) {
           if (!menuActivated) {
             tapCount++;
-            if (tapCount >= 7) {
+            if (tapCount >= _activationTapCount) {
               menuActivated = true;
               Provider.of<UserPreferencesManager>(context, listen: false)
                   .developerModeEnabled = true;
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: Text(
-                      "You have activated the Abogabal secret menu 😎💪 رائع! لقد قمت بتنشيط قائمة أبو جبل السرية"),
-                ),
-              );
+              _showSnackBar(context, _activationMessage);
               tapCount = 0;
             }
           } else {
             menuActivated = false;
             Provider.of<UserPreferencesManager>(context, listen: false)
                 .developerModeEnabled = false;
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(
-                content: Text(
-                    "You have deactivated the Abogabal secret menu 😎💪 رائع! لقد قمت بإلغاء تنشيط قائمة أبو جبل السرية"),
-              ),
-            );
+            _showSnackBar(context, _deactivationMessage);
           }
         }
       },

--- a/lib/src/pages/home/widgets/HomeLogoVersion.dart
+++ b/lib/src/pages/home/widgets/HomeLogoVersion.dart
@@ -3,9 +3,19 @@ import 'package:flutter_svg/svg.dart';
 import 'package:mawaqit/const/resource.dart';
 import 'package:mawaqit/src/helpers/RelativeSizes.dart';
 import 'package:mawaqit/src/widgets/InfoWidget.dart';
+import 'package:provider/provider.dart';
 
-class HomeLogoVersion extends StatelessWidget {
+import '../../../services/user_preferences_manager.dart';
+
+class HomeLogoVersion extends StatefulWidget {
   const HomeLogoVersion({Key? key}) : super(key: key);
+
+  @override
+  _HomeLogoVersionState createState() => _HomeLogoVersionState();
+}
+
+class _HomeLogoVersionState extends State<HomeLogoVersion> {
+  int tapCount = 0;
 
   @override
   Widget build(BuildContext context) {
@@ -13,15 +23,46 @@ class HomeLogoVersion extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          SvgPicture.asset(
-            R.ASSETS_SVG_MAWAQIT_LOGO_TEXT_LIGHT_SVG,
-            height: 3.8.vwr,
+          GestureDetector(
+            onTap: () {
+              if (Provider.of<UserPreferencesManager>(context, listen: false)
+                  .developerModeEnabled) {
+                // Deactivate debug menu
+                Provider.of<UserPreferencesManager>(context, listen: false)
+                    .developerModeEnabled = false;
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(
+                    content: Text(
+                        "You have deactivated the Abogabal secret menu 😎💪 رائع! لقد قمت بإلغاء تنشيط قائمة أبو جبل السرية"),
+                  ),
+                );
+              } else {
+                tapCount++;
+                if (tapCount >= 7) {
+                  Provider.of<UserPreferencesManager>(context, listen: false)
+                      .developerModeEnabled = true;
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: Text(
+                        "You have activated the Abogabal secret menu 😎💪 رائع! لقد قمت بتنشيط قائمة أبو جبل السرية",
+                      ),
+                    ),
+                  );
+                  tapCount = 0; // Reset tapCount after activation
+                }
+              }
+            },
+            child: SvgPicture.asset(
+              R.ASSETS_SVG_MAWAQIT_LOGO_TEXT_LIGHT_SVG,
+              height: 3.8.vwr,
+            ),
           ),
           Align(
             heightFactor: .5,
             alignment: Alignment(.5, 0),
             child: Container(
-              padding: EdgeInsets.symmetric(horizontal: .5.vwr, vertical: .4.vh),
+              padding:
+                  EdgeInsets.symmetric(horizontal: .5.vwr, vertical: .4.vh),
               decoration: BoxDecoration(
                 color: Theme.of(context).primaryColor,
                 borderRadius: BorderRadius.vertical(

--- a/lib/src/pages/home/widgets/HomeLogoVersion.dart
+++ b/lib/src/pages/home/widgets/HomeLogoVersion.dart
@@ -17,6 +17,31 @@ class HomeLogoVersion extends StatefulWidget {
 class _HomeLogoVersionState extends State<HomeLogoVersion> {
   int tapCount = 0;
 
+  static const int _activationTapCount = 7;
+  static const String _activationMessage = "You have activated the Abogabal secret menu 😎💪 رائع! لقد قمت بتنشيط قائمة أبو جبل السرية";
+  static const String _deactivationMessage = "You have deactivated the Abogabal secret menu 😎💪 رائع! لقد قمت بإلغاء تنشيط قائمة أبو جبل السرية";
+
+  void _handleTap() {
+    final userPreferencesManager = Provider.of<UserPreferencesManager>(context, listen: false);
+    if (userPreferencesManager.developerModeEnabled) {
+      userPreferencesManager.developerModeEnabled = false;
+      _showSnackBar(_deactivationMessage);
+    } else {
+      tapCount++;
+      if (tapCount >= _activationTapCount) {
+        userPreferencesManager.developerModeEnabled = true;
+        _showSnackBar(_activationMessage);
+        tapCount = 0; // Reset tapCount after activation
+      }
+    }
+  }
+
+  void _showSnackBar(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return IntrinsicWidth(
@@ -25,32 +50,7 @@ class _HomeLogoVersionState extends State<HomeLogoVersion> {
         children: [
           GestureDetector(
             onTap: () {
-              if (Provider.of<UserPreferencesManager>(context, listen: false)
-                  .developerModeEnabled) {
-                // Deactivate debug menu
-                Provider.of<UserPreferencesManager>(context, listen: false)
-                    .developerModeEnabled = false;
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(
-                    content: Text(
-                        "You have deactivated the Abogabal secret menu 😎💪 رائع! لقد قمت بإلغاء تنشيط قائمة أبو جبل السرية"),
-                  ),
-                );
-              } else {
-                tapCount++;
-                if (tapCount >= 7) {
-                  Provider.of<UserPreferencesManager>(context, listen: false)
-                      .developerModeEnabled = true;
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                      content: Text(
-                        "You have activated the Abogabal secret menu 😎💪 رائع! لقد قمت بتنشيط قائمة أبو جبل السرية",
-                      ),
-                    ),
-                  );
-                  tapCount = 0; // Reset tapCount after activation
-                }
-              }
+              _handleTap();
             },
             child: SvgPicture.asset(
               R.ASSETS_SVG_MAWAQIT_LOGO_TEXT_LIGHT_SVG,
@@ -75,6 +75,7 @@ class _HomeLogoVersionState extends State<HomeLogoVersion> {
               ),
             ),
           ),
+          // ... rest of the widget tree remains unchanged
         ],
       ),
     );

--- a/lib/src/widgets/InfoWidget.dart
+++ b/lib/src/widgets/InfoWidget.dart
@@ -1,61 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:package_info_plus/package_info_plus.dart';
-import 'package:provider/provider.dart';
 
-import '../services/user_preferences_manager.dart';
-
-class VersionWidget extends StatefulWidget {
+class VersionWidget extends StatelessWidget {
   const VersionWidget({Key? key, this.style, this.textAlign}) : super(key: key);
 
   final TextStyle? style;
   final TextAlign? textAlign;
 
   @override
-  _VersionWidgetState createState() => _VersionWidgetState();
-}
-
-class _VersionWidgetState extends State<VersionWidget> {
-  int tapCount = 0;
-
-  @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-onTap: () {
-        setState(() {
-          if (context.read<UserPreferencesManager>().developerModeEnabled) {
-            // Deactivate debug menu
-            context.read<UserPreferencesManager>().developerModeEnabled = false;
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(
-                content: Text(
-                    "You have desactivated the Abogabal secret menu 😎💪 رائع! لقد قمت بإلغاء تنشيط قائمة أبو جبل السرية"),
-              ),
-            );
-          } else {
-            tapCount++;
-            if (tapCount >= 7) {
-              context.read<UserPreferencesManager>().developerModeEnabled =
-                  true;
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: Text(
-                    "You have activated the Abogabal secret menu 😎💪 رائع! لقد قمت بتنشيط قائمة أبو جبل السرية",
-                  ),
-                ),
-              );
-              tapCount = 0; // Reset tapCount after activation
-            }
-          }
-        });
-      },
-
-      child: FutureBuilder<PackageInfo>(
-        future: PackageInfo.fromPlatform(),
-        builder: (context, snapshot) => Text(
-          "v${snapshot.data?.version.replaceAll('-tv', '')}-${snapshot.data?.buildNumber}",
-          style: widget.style,
-          textAlign: widget.textAlign,
-        ),
+    return FutureBuilder<PackageInfo>(
+      future: PackageInfo.fromPlatform(),
+      builder: (context, snapshot) => Text(
+        "v${snapshot.data?.version.replaceAll('-tv', '')}-${snapshot.data?.buildNumber}",
+        style: style,
+        textAlign: textAlign,
       ),
     );
   }

--- a/lib/src/widgets/InfoWidget.dart
+++ b/lib/src/widgets/InfoWidget.dart
@@ -7,12 +7,18 @@ class VersionWidget extends StatelessWidget {
   final TextStyle? style;
   final TextAlign? textAlign;
 
+  String _formatVersion(PackageInfo? packageInfo) {
+    final version = packageInfo?.version.replaceAll('-tv', '') ?? '';
+    final buildNumber = packageInfo?.buildNumber ?? '';
+    return "v$version-$buildNumber";
+  }
+
   @override
   Widget build(BuildContext context) {
     return FutureBuilder<PackageInfo>(
       future: PackageInfo.fromPlatform(),
       builder: (context, snapshot) => Text(
-        "v${snapshot.data?.version.replaceAll('-tv', '')}-${snapshot.data?.buildNumber}",
+        _formatVersion(snapshot.data),
         style: style,
         textAlign: textAlign,
       ),


### PR DESCRIPTION
📝 **Summary**
---
**This PR fixes**  #1001 

**Description**
---
To disable the debug menu, simply tap the logo one time or from the about menu tap one time down arrow.

**Tests**
---
🧪 **Use case 1**
---
💬 **Description:**

Launch the app and tap the logo 7 times to activate the debug menu then tap one time to disable it or from the about menu 7 times down arrow to enable it and one time to disable.
 
📷 **Screenshots or GIFs (if applicable):**



[disableDebugMenu.webm](https://github.com/mawaqit/android-tv-app/assets/35707318/73e803cd-2da1-4bda-9e3b-2819197500fb)








**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).
