### PR TITLE
Refactor: return language selector screen at the onboarding

### DIFF
--- a/lib/src/pages/onBoarding/OnBoardingScreen.dart
+++ b/lib/src/pages/onBoarding/OnBoardingScreen.dart
@@ -17,11 +17,9 @@ import 'package:provider/provider.dart';
 
 import '../../../i18n/AppLanguage.dart';
 import '../../../i18n/l10n.dart';
-import '../../widgets/mawaqit_back_icon_button.dart';
-
 import '../../helpers/LocaleHelper.dart';
 import '../../state_management/on_boarding/on_boarding_notifier.dart';
-
+import '../../widgets/mawaqit_back_icon_button.dart';
 import 'widgets/onboarding_screen_type.dart';
 
 class OnBoardingItem {
@@ -187,17 +185,7 @@ class _OnBoardingScreenState extends riverpod.ConsumerState<OnBoardingScreen> {
               final locale = LocaleHelper.splitLocaleCode(state.language);
               if (sortedLocales.contains(locale)) {
                 String language = locale.languageCode;
-                ref
-                    .read(onBoardingProvider.notifier)
-                    .setLanguage(language, context);
-                var tempOnBoardingItems =
-                    getOnBoardingItems(); // remove language selector
-                setState(() {
-                  tempOnBoardingItems.removeAt(0);
-                });
-                setState(() {
-                  onBoardingItems = tempOnBoardingItems;
-                });
+                ref.read(onBoardingProvider.notifier).setLanguage(language, context);
               }
             }
           },
@@ -218,8 +206,7 @@ class _OnBoardingScreenState extends riverpod.ConsumerState<OnBoardingScreen> {
     );
   }
 
-  WillPopScope buildWillPopScope(
-      OnBoardingItem activePage, BuildContext context) {
+  WillPopScope buildWillPopScope(OnBoardingItem activePage, BuildContext context) {
     return WillPopScope(
       onWillPop: () async {
         if (currentScreen == 0) return true;
@@ -240,11 +227,7 @@ class _OnBoardingScreenState extends riverpod.ConsumerState<OnBoardingScreen> {
               children: [
                 VersionWidget(
                   style: TextStyle(
-                    color: Theme.of(context)
-                        .textTheme
-                        .bodyText1
-                        ?.color
-                        ?.withOpacity(.5),
+                    color: Theme.of(context).textTheme.bodyText1?.color?.withOpacity(.5),
                   ),
                 ),
                 Spacer(flex: 2),
@@ -254,8 +237,7 @@ class _OnBoardingScreenState extends riverpod.ConsumerState<OnBoardingScreen> {
                   decorator: DotsDecorator(
                     size: const Size.square(9.0),
                     activeSize: const Size(21.0, 9.0),
-                    activeShape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(5.0)),
+                    activeShape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(5.0)),
                     spacing: EdgeInsets.all(3),
                   ),
                 ),


### PR DESCRIPTION
📝 **Description**
---
This PR reintroduces the language selection screen at the beginning of the app's onboarding process. This feature was part of the initial app design but was removed in this PR #1018 . By bringing it back, we aim to enhance user experience by allowing users to select their preferred language early on.

**This PR for issue**
- Restores the language selection screen to the app's onboarding flow.

**Tests**
---
🧪 **Use case 1**
---
💬 **Description:**
Tests the functionality of the language selection screen, ensuring that:
- The language screen appears as the first screen during onboarding.
- Users can select a language and proceed to the next step.
- The app correctly applies the selected language throughout the user experience.

📷 **Screenshots or GIFs (if applicable):**

![2024-02-17 00-52-01](https://github.com/mawaqit/android-tv-app/assets/70436855/dde3b5af-1ec5-4e95-8acd-e8d8bd481f8f)

![2024-02-17 00-42-45](https://github.com/mawaqit/android-tv-app/assets/70436855/b7521902-80ff-4605-ba2f-6142422d6c80)

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected. The language selection functionality is restored, and the app correctly adapts to the chosen language.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).

