### PR TITLE
fix: Localization Access in PortraitNormalHome produces Assertion Error

### DIFF
--- a/lib/src/pages/times/normal_home/portrait_normal_home.dart
+++ b/lib/src/pages/times/normal_home/portrait_normal_home.dart
@@ -18,18 +18,18 @@ import '../widgets/jumua_widget.dart';
 class PortraitNormalHome extends StatelessWidget {
   const PortraitNormalHome({super.key});
 
-  String salahName(int index) {
+  String salahName(int index, BuildContext context) {
     switch (index) {
       case 0:
-        return S.current.fajr;
+        return S.of(context).fajr;
       case 1:
-        return S.current.duhr;
+        return S.of(context).duhr;
       case 2:
-        return S.current.asr;
+        return S.of(context).asr;
       case 3:
-        return S.current.maghrib;
+        return S.of(context).maghrib;
       case 4:
-        return S.current.isha;
+        return S.of(context).isha;
       default:
         return '';
     }
@@ -67,7 +67,7 @@ class PortraitNormalHome extends StatelessWidget {
               children: [
                 for (var i = 0; i < 5; i++)
                   HorizontalSalahItem(
-                    title: salahName(i),
+                    title: salahName(i, context),
                     time: times[i],
                     isIqamaMoreImportant: isIqamaMoreImportant,
 


### PR DESCRIPTION
📝 **Summary**
---

**This PR for issue**   #1043 

**This PR fixes the issue encountered in the `PortraitNormalHome` widget where accessing localized strings using `S.current` was causing runtime assertion errors due to the localization delegate not being initialized at the time of access.**

**Description**
---
This PR fixes the `PortraitNormalHome` widget to access localized strings through `S.of(context)`, ensuring the localization delegate is properly initialized before use. This change addresses the runtime assertion error and aligns with Flutter's recommended practices for localization.

**Tests**
---
🧪 **Use case 1**
---
💬 **Description:**
The primary use case tested is the initialization and display of the `PortraitNormalHome` widget

📷 **Screenshots or GIFs (if applicable):**

![2024-02-24 02-41-47](https://github.com/mawaqit/android-tv-app/assets/70436855/765d3555-e606-41e2-854e-b9bed498180b)


**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected. The `PortraitNormalHome` widget now correctly accesses localized strings without encountering runtime assertion errors.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).
