### PR TITLE
Fix/ Implement Asset-Based Audio Playback in AudioManager

### DIFF
--- a/lib/src/services/audio_manager.dart
+++ b/lib/src/services/audio_manager.dart
@@ -23,7 +23,8 @@ class AudioManager extends ChangeNotifier {
     policy: CachePolicy.request,
   );
 
-  late final dio = Dio()..interceptors.add(DioCacheInterceptor(options: option));
+  late final dio = Dio()
+    ..interceptors.add(DioCacheInterceptor(options: option));
 
   String adhanLink(MosqueConfig? mosqueConfig, {bool useFajrAdhan = false}) {
     String adhanLink = "$kStaticFilesUrl/mp3/adhan-afassy.mp3";
@@ -39,7 +40,6 @@ class AudioManager extends ChangeNotifier {
     return adhanLink;
   }
 
-
   /// Plays audio from provided ByteData.
   ///
   /// This method does not need to know the source of the ByteData, enabling
@@ -48,8 +48,8 @@ class AudioManager extends ChangeNotifier {
   /// Parameters:
   /// - [byteData]: The ByteData of the audio file to be played.
   /// - [onDone]: A callback that gets called when audio playback is complete.
-  Future<void> loadAndPlayFromByteData(ByteData byteData, {VoidCallback? onDone}) async {
-
+  Future<void> loadAndPlayFromByteData(ByteData byteData,
+      {VoidCallback? onDone}) async {
     // Load and play the audio from ByteData
     player = Audio.loadFromByteData(
       byteData,
@@ -64,14 +64,13 @@ class AudioManager extends ChangeNotifier {
     )..play();
   }
 
-
   void loadAndPlayAdhanVoice(
     MosqueConfig? mosqueConfig, {
     VoidCallback? onDone,
     bool useFajrAdhan = false,
   }) {
     final url = adhanLink(mosqueConfig, useFajrAdhan: useFajrAdhan);
-    if(url.contains('bip')) {
+    if (url.contains('bip')) {
       loadAndPlayIqamaBipVoice(mosqueConfig, onDone: onDone);
     } else {
       loadAndPlay(
@@ -96,10 +95,12 @@ class AudioManager extends ChangeNotifier {
   }
 
   Future<void> loadAssetsAndPlay(String assets, {VoidCallback? onDone}) async {
+    final file = await getFileFromAssets(R.ASSETS_VOICES_ADHAN_BIP_MP3);
+
     if (player != null) stop();
 
-    player = Audio.load(
-      assets,
+    player = Audio.loadFromByteData(
+      file,
       onComplete: () {
         stop();
         onDone?.call();


### PR DESCRIPTION
**Description**
---
This PR fixes audio playback feature to play the audio from the bytedata not relative path to work correctly on AndroidBox.

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected, including offline playback and initial load time improvements.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).

