### PR TITLE
Fix/ Unable to add mosque type home on Onboarding process

### DIFF
--- a/lib/src/pages/mosque_search/widgets/MosqueInputId.dart
+++ b/lib/src/pages/mosque_search/widgets/MosqueInputId.dart
@@ -106,8 +106,6 @@ class _MosqueInputIdState extends State<MosqueInputId> {
                         error = S.of(context).slugError;
                       });
                     } else {
-                      debugPrintStack(stackTrace: stack, label: e.toString());
-
                       setState(() {
                         loading = false;
                         error = S.of(context).backendError;

--- a/lib/src/pages/mosque_search/widgets/MosqueInputId.dart
+++ b/lib/src/pages/mosque_search/widgets/MosqueInputId.dart
@@ -10,6 +10,9 @@ import 'package:mawaqit/src/services/mosque_manager.dart';
 import 'package:mawaqit/src/widgets/mosque_simple_tile.dart';
 import 'package:provider/provider.dart';
 
+import '../../../helpers/AppRouter.dart';
+import '../../home/OfflineHomeScreen.dart';
+
 class MosqueInputId extends StatefulWidget {
   const MosqueInputId({Key? key, this.onDone}) : super(key: key);
 
@@ -93,14 +96,18 @@ class _MosqueInputIdState extends State<MosqueInputId> {
                       .read<MosqueManager>()
                       .setMosqueUUid(searchOutput!.uuid.toString())
                       .then((value) {
-                    widget.onDone?.call();
-                  }).catchError((e) {
+                    !context.read<MosqueManager>().typeIsMosque
+                        ? AppRouter.pushReplacement(OfflineHomeScreen())
+                        : widget.onDone?.call();
+                  }).catchError((e, stack) {
                     if (e is InvalidMosqueId) {
                       setState(() {
                         loading = false;
                         error = S.of(context).slugError;
                       });
                     } else {
+                      debugPrintStack(stackTrace: stack, label: e.toString());
+
                       setState(() {
                         loading = false;
                         error = S.of(context).backendError;

--- a/lib/src/pages/mosque_search/widgets/MosqueInputSearch.dart
+++ b/lib/src/pages/mosque_search/widgets/MosqueInputSearch.dart
@@ -8,6 +8,9 @@ import 'package:mawaqit/src/services/mosque_manager.dart';
 import 'package:mawaqit/src/widgets/mosque_simple_tile.dart';
 import 'package:provider/provider.dart';
 
+import '../../../helpers/AppRouter.dart';
+import '../../home/OfflineHomeScreen.dart';
+
 class MosqueInputSearch extends StatefulWidget {
   const MosqueInputSearch({Key? key, this.onDone}) : super(key: key);
 
@@ -78,7 +81,9 @@ class _MosqueInputSearchState extends State<MosqueInputSearch> {
         .read<MosqueManager>()
         .setMosqueUUid(mosque.uuid.toString())
         .then((value) {
-      widget.onDone?.call();
+      !context.read<MosqueManager>().typeIsMosque
+          ? AppRouter.pushReplacement(OfflineHomeScreen())
+          : widget.onDone?.call();
     }).catchError((e, stack) {
       if (e is InvalidMosqueId) {
         setState(() {


### PR DESCRIPTION
- This PR fixes invalid range value which occurs when adding a mosque type home on the onboarding process by calling directly `AppRouter.pushReplacement(OfflineHomeScreen())` instead of the `onDone` callback