### PR TITLE
fix: Background image not persisting after box force restart in both offline & online mode

### DIFF
--- a/lib/src/const/constants.dart
+++ b/lib/src/const/constants.dart
@@ -12,3 +12,7 @@ const kStagingStaticFilesUrl = 'https://staging.mawaqit.net/static';
 
 const kApiToken = String.fromEnvironment('mawaqit.api.key');
 const kSentryDns = String.fromEnvironment('mawaqit.sentry.dns');
+
+abstract class CacheKey {
+  static const String kMosqueBackgroundScreen = 'mosque_background_screen';
+}

--- a/lib/src/pages/home/widgets/mosque_background_screen.dart
+++ b/lib/src/pages/home/widgets/mosque_background_screen.dart
@@ -1,76 +1,126 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:mawaqit/src/helpers/AppRouter.dart';
 import 'package:mawaqit/src/helpers/HexColor.dart';
-import 'package:mawaqit/src/mawaqit_image/mawaqit_image_cache.dart';
-import 'package:mawaqit/src/pages/home/OfflineHomeScreen.dart';
 import 'package:mawaqit/src/services/mosque_manager.dart';
 import 'package:mawaqit/src/widgets/MawaqitDrawer.dart';
 import 'package:provider/provider.dart';
 
-/// used to show the background of the mosque
-/// used with the sunscreens
-/// in case you need to show sub screen without the [OfflineHomeScreen]
-class MosqueBackgroundScreen extends StatefulWidget {
-  MosqueBackgroundScreen({Key? key, required this.child}) : super(key: key);
+import '../../../const/constants.dart';
 
+class MosqueBackgroundScreen extends StatefulWidget {
   final Widget child;
+
+  const MosqueBackgroundScreen({Key? key, required this.child}) : super(key: key);
 
   @override
   State<MosqueBackgroundScreen> createState() => _MosqueBackgroundScreenState();
 }
 
 class _MosqueBackgroundScreenState extends State<MosqueBackgroundScreen> {
-  final _scaffoldKey = GlobalKey<ScaffoldState>();
+  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
+  late FocusNode _focusNode;
+
+  @override
+  void initState() {
+    super.initState();
+    _focusNode = FocusNode();
+  }
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     final mosqueProvider = context.watch<MosqueManager>();
-    final mosqueConfig = mosqueProvider.mosqueConfig;
-
-    if (!mosqueProvider.loaded) return SizedBox();
-
+    if (!mosqueProvider.loaded) return const SizedBox();
     return RawKeyboardListener(
-       focusNode: FocusNode(),
-       onKey: (event) {
-         if (event is RawKeyDownEvent) {
-           if (event.logicalKey == LogicalKeyboardKey.arrowDown ||
-               event.logicalKey == LogicalKeyboardKey.arrowUp ||
-               event.logicalKey == LogicalKeyboardKey.arrowLeft ||
-               event.logicalKey == LogicalKeyboardKey.arrowRight) {
-             _scaffoldKey.currentState?.openDrawer();
-           }
-         }
-       },
+      focusNode: _focusNode,
+      onKey: (event) {
+        if (event is RawKeyDownEvent && event.isArrow) {
+          _scaffoldKey.currentState?.openDrawer();
+        }
+      },
       child: Focus(
         autofocus: true,
         child: Scaffold(
           key: _scaffoldKey,
           drawer: MawaqitDrawer(goHome: () => AppRouter.popAll()),
-          body: Container(
-            width: double.infinity,
-            height: double.infinity,
-            decoration: mosqueConfig!.backgroundType == "color"
-                ? BoxDecoration(color: HexColor(mosqueConfig.backgroundColor))
-                : BoxDecoration(
-                    image: DecorationImage(
-                      image: mosqueConfig.backgroundMotif == "0"
-                          ? MawaqitNetworkImageProvider(mosqueProvider.mosque?.interiorPicture ?? "")
-                          : mosqueConfig.backgroundMotif == "-1"
-                              ? MawaqitNetworkImageProvider(mosqueProvider.mosque?.exteriorPicture ?? "")
-                              : MawaqitNetworkImageProvider(mosqueProvider.mosqueConfig!.motifUrl),
-                      fit: BoxFit.cover,
-                      colorFilter: ColorFilter.mode(
-                        Colors.black.withOpacity(.4),
-                        BlendMode.srcOver,
-                      ),
-                      onError: (exception, stackTrace) {},
-                    ),
-                  ),
-            child: RepaintBoundary(child: widget.child),
-          ),
+          body: _buildBackgroundDecoration(mosqueProvider),
         ),
       ),
     );
   }
+
+  Widget _buildBackgroundDecoration(MosqueManager mosqueProvider) {
+    final mosqueConfig = mosqueProvider.mosqueConfig!;
+    if (mosqueConfig.backgroundType == "color") {
+      return Container(
+        width: double.infinity,
+        height: double.infinity,
+        color: HexColor(mosqueConfig.backgroundColor),
+        child: RepaintBoundary(child: widget.child),
+      );
+    } else {
+      String imageUrl = '';
+      switch (mosqueConfig.backgroundMotif) {
+        case "0":
+          imageUrl = mosqueProvider.mosque?.interiorPicture ?? "";
+          break;
+        case "-1":
+          imageUrl = mosqueProvider.mosque?.exteriorPicture ?? "";
+          break;
+        default:
+          imageUrl = mosqueConfig.motifUrl;
+      }
+
+      return CachedNetworkImage(
+        cacheKey: CacheKey.kMosqueBackgroundScreen,
+        imageUrl: imageUrl,
+        imageBuilder: (context, imageProvider) {
+          return Container(
+            width: double.infinity,
+            height: double.infinity,
+            child: RepaintBoundary(child: widget.child),
+            decoration: BoxDecoration(
+              image: DecorationImage(
+                image: imageProvider,
+                fit: BoxFit.cover,
+                colorFilter: ColorFilter.mode(Colors.black.withOpacity(.4), BlendMode.srcOver),
+              ),
+            ),
+          );
+        },
+        placeholder: (context, url) {
+          return Center(
+            child: SizedBox(
+              width: 40,
+              height: 40,
+              child: CircularProgressIndicator(
+                valueColor: AlwaysStoppedAnimation<Color>(Theme.of(context).primaryColor), // Green color
+              ),
+            ),
+          );
+        },
+        errorWidget: (context, url, error) => Container(
+          width: double.infinity,
+          height: double.infinity,
+          color: Colors.black,
+          child: RepaintBoundary(child: widget.child),
+        ),
+      );
+    }
+  }
+}
+
+extension on RawKeyDownEvent {
+  bool get isArrow =>
+      logicalKey == LogicalKeyboardKey.arrowDown ||
+      logicalKey == LogicalKeyboardKey.arrowUp ||
+      logicalKey == LogicalKeyboardKey.arrowLeft ||
+      logicalKey == LogicalKeyboardKey.arrowRight;
 }


### PR DESCRIPTION
📝 **Summary**
---
This PR addresses an issue where users were experiencing a black background during image at the offline mode. The solution involves implementing an effective caching strategy for the background image.

**This PR for issue:**  #1059 

**Description**
---
The core of this update is the integration of the `CachedNetworkImage` widget to replace the direct fetching method previously used for the mosque background screen. By utilizing a caching mechanism, the app now efficiently manages the background image, ensuring that users are not greeted with a black screen while the image loads.

**Implementation include:**
- Introduction of a `CacheKey` class for better cache key management.
- Utilization of `CachedNetworkImage` for efficient image loading and caching.
- Refactor the code of the `mosque_background_screen` for better readability

**Tests**
---
🧪 **Use case 1**
---
💬 **Description:** Verifying that the background image loads efficiently and the black screen issue is resolved.

1. Launch the app and navigate to the Mosque Background Screen.
2. Unplug the box from electricity and replug it to restart.
3. The app relaunches with the background image.

📷 **Screenshots or GIFs (if applicable):**
NA

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).
