### PR TITLE
refactor: AppDate for Improved Debug Time Flexibility

### DIFF
--- a/lib/src/helpers/AppDate.dart
+++ b/lib/src/helpers/AppDate.dart
@@ -24,12 +24,21 @@ class FeatureManagerProvider {
 class AppDateTime {
   AppDateTime._();
 
-  static Duration get difference =>
-      Duration(days: 30 * 8 + 6, hours: -6, minutes: 30);
+  // Initial setup for debug time; can be replaced or modified as needed.
+  static final DateTime _initialRealTime = DateTime.now();
+  static final DateTime _initialDebugTime = DateTime(
+    _initialRealTime.year,
+    _initialRealTime.month,
+    _initialRealTime.day,
+    13,
+    5
+  );
+
+  static final Duration _timeDifference = _initialDebugTime.difference(_initialRealTime);
 
   static DateTime now() {
     if (kDebugMode) {
-      return DateTime.now().add(difference);
+      return DateTime.now().add(_timeDifference);
     } else {
       return FeatureManagerProvider.featureManager
                   .isFeatureEnabled("timezone_shift") &&


### PR DESCRIPTION
📝 **Summary**
---
This PR introduces improvements to the handling of debug time in the application, making it easier to test and debug time-related features.

**This PR is for issue**  
#1075 

**Description**
---
The changes in this PR refactor the way debug time is calculated and used within the application. Previously, a static `difference` was used to simulate time changes for debugging. This approach was less flexible and could lead to confusion during development. The new implementation introduces `_initialRealTime` and `_initialDebugTime`, along with a computed `_timeDifference` that allows for more intuitive and manageable debugging of time-dependent features. This change aims to facilitate easier testing and development by providing a clear and adjustable method for simulating different times within the app.

**Tests**
---
🧪 **Use case 1**
---
💬 **Description:** Testing the functionality of the debug time adjustment feature.
1. Ensure the application is in debug mode.
2. Observe the application's behavior at the simulated debug time.
3. Adjust `_initialDebugTime` to a different time.
4. Verify that the application now reflects the newly adjusted time.

📷 **Screenshots or GIFs (if applicable):**

<img width="1297" alt="image" src="https://github.com/mawaqit/android-tv-app/assets/70436855/f1dfa8a0-8e57-41b2-a148-6494f8aa540e">

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).
