### PR TITLE
Fix/ Wrong jumua time displayed

### DIFF
--- a/lib/src/pages/home/workflow/jumua_workflow_screen.dart
+++ b/lib/src/pages/home/workflow/jumua_workflow_screen.dart
@@ -19,9 +19,11 @@ class JumuaaWorkflowScreen extends StatelessWidget {
     final now = mosqueManager.mosqueDate();
 
     final jumuaaTimeout = mosqueManager.mosqueConfig?.jumuaTimeout ?? 30;
-    final salahTime = int.tryParse(mosqueManager.mosqueConfig!.duaAfterPrayerShowTimes[1]) ?? 0;
+    final salahTime =
+        int.tryParse(mosqueManager.mosqueConfig!.duaAfterPrayerShowTimes[1]) ??
+            0;
 
-    final jumuaaTime = mosqueManager.jumuaTime!.toTimeOfDay()!.toDate(now);
+    final jumuaaTime = mosqueManager.activeJumuaaDate();
     final jumuaaEndTime = jumuaaTime.add(Duration(minutes: jumuaaTimeout));
 
     return ContinuesWorkFlowWidget(
@@ -39,7 +41,9 @@ class JumuaaWorkflowScreen extends StatelessWidget {
           skip: now.isAfter(jumuaaEndTime),
 
           /// handle if user open screen during the jumuaa
-          duration: now.isBefore(jumuaaTime) ? Duration(minutes: jumuaaTimeout) : jumuaaEndTime.difference(now),
+          duration: now.isBefore(jumuaaTime)
+              ? Duration(minutes: jumuaaTimeout)
+              : jumuaaEndTime.difference(now),
         ),
 
         // salah time after jumuaa

--- a/lib/src/pages/times/widgets/jumua_widget.dart
+++ b/lib/src/pages/times/widgets/jumua_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/widgets.dart';
+import 'package:intl/intl.dart';
 import 'package:mawaqit/i18n/l10n.dart';
 import 'package:mawaqit/src/helpers/AppDate.dart';
 import 'package:mawaqit/src/pages/home/widgets/FadeInOut.dart';
@@ -37,7 +38,8 @@ class JumuaWidget extends StatelessWidget {
       title: S.of(context).salatElEid,
       iqama: mosqueManager.times!.aidPrayerTime2,
       time: mosqueManager.times!.aidPrayerTime ?? "",
-      isIqamaMoreImportant: mosqueManager.mosqueConfig!.iqamaMoreImportant == true,
+      isIqamaMoreImportant:
+          mosqueManager.mosqueConfig!.iqamaMoreImportant == true,
     );
   }
 
@@ -46,10 +48,13 @@ class JumuaWidget extends StatelessWidget {
       withDivider: true,
       removeBackground: true,
       title: S.of(context).jumua,
-      time: mosqueManager.jumuaTime ?? "",
+      time: DateFormat.Hm().format(mosqueManager.activeJumuaaDate()) ?? "",
       iqama: mosqueManager.times!.jumua2,
-      isIqamaMoreImportant: mosqueManager.mosqueConfig!.iqamaMoreImportant == true,
-      active: mosqueManager.nextIqamaIndex() == 1 && AppDateTime.isFriday && mosqueManager.times?.jumua != null,
+      isIqamaMoreImportant:
+          mosqueManager.mosqueConfig!.iqamaMoreImportant == true,
+      active: mosqueManager.nextIqamaIndex() == 1 &&
+          AppDateTime.isFriday &&
+          mosqueManager.times?.jumua != null,
     );
   }
 }

--- a/lib/src/services/mixins/mosque_helpers_mixins.dart
+++ b/lib/src/services/mixins/mosque_helpers_mixins.dart
@@ -281,10 +281,10 @@ mixin MosqueHelpersMixin on ChangeNotifier {
   @Deprecated('Use times.dayIqamaStrings')
   List<String> get tomorrowIqama => iqamasOfDay(mosqueDate().add(Duration(days: 1)));
 
-  /// if jumua as duhr return jumua
+/*   /// if jumua as duhr return jumua
   String? get jumuaTime {
     return times!.jumuaAsDuhr ? todayTimes[1] : times!.jumua;
-  }
+  } */
 
   DateTime nextFridayDate([DateTime? now]) {
     now ??= mosqueDate();
@@ -323,7 +323,7 @@ mixin MosqueHelpersMixin on ChangeNotifier {
   /// we are in jumuaa workflow time
   bool jumuaaWorkflowTime() {
     final now = mosqueDate();
-    final jumuaaStartTime = jumuaTime?.toTimeOfDay()?.toDate(now);
+    final jumuaaStartTime = activeJumuaaDate();
     final jumuaaEndTime = jumuaaStartTime?.add(
       Duration(minutes: mosqueConfig?.jumuaTimeout ?? 30) + kAzkarDuration,
     );


### PR DESCRIPTION
📝 **Summary**
---
**This PR fixes**  #1078 

**Description**
---
It sets the correct getter to display the correct jumua time if is set same as duhr.

**Tests**
---
🧪 **Use case 1**
---
💬 **Description:**

Set Jumua time same as duhr on the backoffice and check the value on the home screen.
 
📷 **Screenshots or GIFs (if applicable):**

![Screenshot_1711381079](https://github.com/mawaqit/android-tv-app/assets/35707318/5c83b9bc-c35f-4d5d-a5ca-bf4ff83c64a5)



**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).
