### PR TITLE
Fix/ Flash message display logic

### DIFF
--- a/lib/src/pages/home/widgets/FlashWidget.dart
+++ b/lib/src/pages/home/widgets/FlashWidget.dart
@@ -3,6 +3,7 @@ import 'package:marquee/marquee.dart';
 import 'package:mawaqit/src/helpers/RelativeSizes.dart';
 import 'package:mawaqit/src/models/mosque.dart';
 import 'package:provider/provider.dart';
+import '../../../helpers/AppDate.dart';
 import '../../../helpers/HexColor.dart';
 import '../../../services/mosque_manager.dart';
 import '../../../themes/UIShadows.dart';
@@ -26,9 +27,18 @@ class _FlashWidgetState extends State<FlashWidget> {
     final startDate = DateTime.tryParse(mosque.flash?.startDate ?? 'x');
     final endDate = DateTime.tryParse(mosque.flash?.endDate ?? 'x');
 
-    if (startDate != null && endDate != null) {
+    if (endDate != null) {
       final now = DateTime.now();
-      enabled = now.isAfter(startDate) && now.isBefore(endDate);
+      final endOfDay =
+          DateTime(endDate.year, endDate.month, endDate.day, 23, 59, 59);
+
+      if (startDate != null) {
+        final startOfDay =
+            DateTime(startDate.year, startDate.month, startDate.day);
+        enabled = now.isAfter(startOfDay) && now.isBefore(endOfDay);
+      } else {
+        enabled = now.isBefore(endOfDay);
+      }
     }
 
     super.initState();

--- a/lib/src/pages/home/widgets/FlashWidget.dart
+++ b/lib/src/pages/home/widgets/FlashWidget.dart
@@ -4,6 +4,7 @@ import 'package:mawaqit/src/helpers/RelativeSizes.dart';
 import 'package:mawaqit/src/models/mosque.dart';
 import 'package:provider/provider.dart';
 import '../../../helpers/HexColor.dart';
+import '../../../models/flash.dart';
 import '../../../services/mosque_manager.dart';
 import '../../../themes/UIShadows.dart';
 
@@ -15,45 +16,20 @@ class FlashWidget extends StatefulWidget {
 }
 
 class _FlashWidgetState extends State<FlashWidget> {
-  var enabled = true;
-  late final Mosque mosque;
-
-  @override
-  void initState() {
-    final mosqueProvider = context.read<MosqueManager>();
-    mosque = mosqueProvider.mosque!;
-
-    final startDate = DateTime.tryParse(mosque.flash?.startDate ?? 'x');
-    final endDate = DateTime.tryParse(mosque.flash?.endDate ?? 'x');
-
-    if (endDate != null) {
-      final now = DateTime.now();
-      final endOfDay =
-          DateTime(endDate.year, endDate.month, endDate.day, 23, 59, 59);
-
-      if (startDate != null) {
-        final startOfDay =
-            DateTime(startDate.year, startDate.month, startDate.day);
-        enabled = now.isAfter(startOfDay) && now.isBefore(endOfDay);
-      } else {
-        enabled = now.isBefore(endOfDay);
-      }
-    }
-
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {
-    if (!enabled) return SizedBox();
+    final isFlashEnabled = context.select<MosqueManager, bool>((mosque) => mosque.flashEnabled);
+    final flash = context.select<MosqueManager, Flash?>((mosque) => mosque.mosque?.flash);
+    if (!isFlashEnabled) return SizedBox();
 
     return RepaintBoundary(
       child: Marquee(
-        key: ValueKey(mosque.flash?.content),
-        textDirection: mosque.flash?.orientation == 'rtl'
+        key: ValueKey(flash!.content),
+        textDirection: flash.orientation == 'rtl'
             ? TextDirection.rtl
             : TextDirection.ltr,
-        text: mosque.flash?.content ?? '',
+        text: flash.content ?? '',
         velocity: 90,
         blankSpace: 400,
         style: TextStyle(
@@ -62,7 +38,7 @@ class _FlashWidgetState extends State<FlashWidget> {
           fontWeight: FontWeight.bold,
           wordSpacing: 3,
           shadows: kHomeTextShadow,
-          color: HexColor(mosque.flash?.color ?? "#FFFFFF"),
+          color: HexColor(flash.color ?? "#FFFFFF"),
         ),
       ),
     );

--- a/lib/src/pages/home/widgets/FlashWidget.dart
+++ b/lib/src/pages/home/widgets/FlashWidget.dart
@@ -3,7 +3,6 @@ import 'package:marquee/marquee.dart';
 import 'package:mawaqit/src/helpers/RelativeSizes.dart';
 import 'package:mawaqit/src/models/mosque.dart';
 import 'package:provider/provider.dart';
-import '../../../helpers/AppDate.dart';
 import '../../../helpers/HexColor.dart';
 import '../../../services/mosque_manager.dart';
 import '../../../themes/UIShadows.dart';

--- a/lib/src/services/mosque_manager.dart
+++ b/lib/src/services/mosque_manager.dart
@@ -18,6 +18,7 @@ import 'package:mawaqit/src/services/mixins/mosque_helpers_mixins.dart';
 import 'package:mawaqit/src/services/mixins/random_hadith_mixin.dart';
 import 'package:mawaqit/src/services/mixins/weather_mixin.dart';
 
+import '../helpers/AppDate.dart';
 import 'mixins/audio_mixin.dart';
 import 'mixins/connectivity_mixin.dart';
 
@@ -34,6 +35,36 @@ class MosqueManager extends ChangeNotifier
 
   // String? mosqueId;
   String? mosqueUUID;
+
+  bool _flashEnabled = false;
+  bool get flashEnabled => _flashEnabled;
+
+  void _updateFlashEnabled() {
+    if (mosque != null) {
+      final startDate = DateTime.tryParse(mosque!.flash?.startDate ?? 'x');
+      final endDate = DateTime.tryParse(mosque!.flash?.endDate ?? 'x');
+      final currentDate = AppDateTime.now();
+
+      DateTime? endOfDay;
+      if (endDate != null) {
+        endOfDay = DateTime(endDate.year, endDate.month, endDate.day, 23, 59, 59);
+      }
+
+      if (startDate == null && endDate == null) {
+        _flashEnabled = true;
+      } else if (startDate != null && endDate == null) {
+        _flashEnabled = currentDate.isAfter(startDate) || currentDate.isAtSameMomentAs(startDate);
+      } else if (startDate == null && endDate != null) {
+        _flashEnabled = currentDate.isBefore(endOfDay!) || currentDate.isAtSameMomentAs(endOfDay);
+      } else if (startDate != null && endDate != null) {
+        _flashEnabled = currentDate.isAfter(startDate) && currentDate.isBefore(endOfDay!) ||
+            currentDate.isAtSameMomentAs(startDate) ||
+            currentDate.isAtSameMomentAs(endOfDay!);
+      }
+      notifyListeners();
+    }
+  }
+
 
   bool get loaded => mosque != null && times != null && mosqueConfig != null;
 
@@ -134,6 +165,7 @@ class MosqueManager extends ChangeNotifier
     _mosqueSubscription = mosqueStream.listen(
       (e) {
         mosque = e;
+        _updateFlashEnabled();
         notifyListeners();
       },
       onError: onItemError,


### PR DESCRIPTION
📝 **Summary**
---
**This PR fixes**  #1036  & #972 

**Description**
---
Fix flash message display logic to handle all cases for start & end date. 

**Tests**
---
🧪 **Use case 1**
---
💬 **Description:**

Only Startdate selected the flash message should display starting that date until the user cancel it . 

🧪 **Use case 2**
---
💬 **Description:**

Only Enddate selected the flash message should display immediately until passing the endDate . 

🧪 **Use case 3**
---
💬 **Description:**

Both start & end date selected the flash message should display between the selected values. 

🧪 **Use case 4**
---
💬 **Description:**

Neither start or end date is selected the flash message should always display until the user cancel it. 

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).
