### PR TITLE
fix remove background cache

### DIFF
--- a/lib/src/pages/home/widgets/mosque_background_screen.dart
+++ b/lib/src/pages/home/widgets/mosque_background_screen.dart
@@ -77,9 +77,7 @@ class _MosqueBackgroundScreenState extends State<MosqueBackgroundScreen> {
         default:
           imageUrl = mosqueConfig.motifUrl;
       }
-
       return CachedNetworkImage(
-        cacheKey: CacheKey.kMosqueBackgroundScreen,
         imageUrl: imageUrl,
         imageBuilder: (context, imageProvider) {
           return Container(


### PR DESCRIPTION
📝 **Summary**
---
**This PR addresses the issue of optimizing the loading and caching mechanism for mosque backgrounds** to ensure smoother transitions and reduce data usage by eliminating redundant network requests.

**Description**
---
This update simplifies the caching strategy for mosque background images. By leveraging the `CachedNetworkImage` widget's inherent caching capabilities, we remove the need for explicit cache key management. This change aims to cache mosque background images.

**Tests**
---
🧪 **Use case 1**
---
💬 **Description:**
Tested the loading and display of mosque background images across different devices and network conditions. The focus was to verify that images are properly cached and reused without unnecessary network requests, ensuring that background images load.

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected, with background images loading faster and using the cache effectively.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).
