### PR TITLE
fix: The pictures in announcements are not fitting the screen

### DIFF
--- a/lib/src/pages/home/sub_screens/AnnouncementScreen.dart
+++ b/lib/src/pages/home/sub_screens/AnnouncementScreen.dart
@@ -176,7 +176,7 @@ class _ImageAnnouncement extends StatelessWidget {
   Widget build(BuildContext context) {
     return Image(
       image: MawaqitNetworkImageProvider(image, onError: onError),
-      fit: BoxFit.fitWidth,
+      fit: BoxFit.fill,
       width: double.infinity,
       height: double.infinity,
     ).animate().slideX().addRepaintBoundary();


### PR DESCRIPTION
📝 **Summary**
---
This PR fixes #1019 

**Description**
---
Currently, the pictures in announcements are not properly fitting the screen, especially on tablets, leaving small margins at the top and bottom. This issue affects the visual presentation and user experience of the announcement screen.

To address this issue, the following changes have been made:

1. In the `AnnouncementScreen.dart` file, the `fit` property of the `Image` widget has been changed from `BoxFit.fitWidth` to `BoxFit.fill`.
2. The `BoxFit.fill` value ensures that the image fills the entire available space of the widget, both horizontally and vertically, while maintaining its aspect ratio.

By making this change, the pictures in announcements will now properly fit the screen, eliminating the small margins at the top and bottom, resulting in an improved visual presentation.

**Tests**
---
🧪 **Use case 1**
---
💬 **Description:**
1. Launch the app on a tablet device.
2. Navigate to the announcement screen.
3. Verify that the picture in the announcement fills the entire screen, without any visible margins at the top or bottom.

📷 **Screenshots or GIFs (if applicable):**

<img width="1178" alt="image" src="https://github.com/mawaqit/android-tv-app/assets/70436855/fb936aa2-d254-424a-a082-cdd39ff7be3f">


**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).