### PR TITLE
Fix/ Settings item text color

### DIFF
--- a/lib/src/pages/SettingScreen.dart
+++ b/lib/src/pages/SettingScreen.dart
@@ -229,7 +229,7 @@ class _SettingItem extends StatelessWidget {
                 maxLines: 2,
                 overflow: TextOverflow.ellipsis,
                 style: TextStyle(
-                    fontSize: 10, color: Colors.white.withOpacity(0.7)))
+                    fontSize: 10))
             : null,
         onTap: onTap,
       ),


### PR DESCRIPTION
📝 **Summary**
---
**This PR fixes**  #1064

**Description**
---
Change the color to black in white mode for the setting items.
 
📷 **Screenshots or GIFs (if applicable):**

![Screenshot_1712241218](https://github.com/mawaqit/android-tv-app/assets/35707318/f25ac2ac-a2d2-4d24-828e-d7f178d52445)



**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).
