### PR TITLE
fix: The font size of the second Jumua and Salat El Eid is larger than the first font.

### DIFF
--- a/lib/src/pages/times/widgets/jumua_widget.dart
+++ b/lib/src/pages/times/widgets/jumua_widget.dart
@@ -38,8 +38,7 @@ class JumuaWidget extends StatelessWidget {
       title: S.of(context).salatElEid,
       iqama: mosqueManager.times!.aidPrayerTime2,
       time: mosqueManager.times!.aidPrayerTime ?? "",
-      isIqamaMoreImportant:
-          mosqueManager.mosqueConfig!.iqamaMoreImportant == true,
+      isIqamaMoreImportant: false,
     );
   }
 
@@ -50,11 +49,8 @@ class JumuaWidget extends StatelessWidget {
       title: S.of(context).jumua,
       time: DateFormat.Hm().format(mosqueManager.activeJumuaaDate()) ?? "",
       iqama: mosqueManager.times!.jumua2,
-      isIqamaMoreImportant:
-          mosqueManager.mosqueConfig!.iqamaMoreImportant == true,
-      active: mosqueManager.nextIqamaIndex() == 1 &&
-          AppDateTime.isFriday &&
-          mosqueManager.times?.jumua != null,
+      isIqamaMoreImportant: false,
+      active: mosqueManager.nextIqamaIndex() == 1 && AppDateTime.isFriday && mosqueManager.times?.jumua != null,
     );
   }
 }


### PR DESCRIPTION
📝 **Summary**
---
**This PR fixes the issue where the font size of the second Jumua and Salat El Eid is larger than the first font.**

**This PR for issue**  : #1101 

**Description**
---
This PR addresses the issue where the font size of the second Jumua and Salat El Eid is larger than the first font. The changes made in this PR ensure that the font sizes are consistent across all the elements in the `jumua_widget.dart` file.

**Tests**
---
🧪 **Use case 1: Verify Jumua and Salat El Eid font sizes**
---
💬 **Description:** Ensure that the font sizes for the title, time, and iqama of both the Jumua and Salat El Eid are consistent.

![image](https://github.com/mawaqit/android-tv-app/assets/70436855/fa9cc08e-8c04-4ba9-ae92-90762fdfb776)

![image](https://github.com/mawaqit/android-tv-app/assets/70436855/bb7b1877-7606-418f-b91d-8a609e42e07b)


📷 **Screenshots or GIFs (if applicable):**
<screenshot or GIF showing the consistent font sizes>

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).