### PR TITLE
fix: connectivity service using `internet_connection_checker_plus`

### DIFF
--- a/lib/src/helpers/connectivity_provider.dart
+++ b/lib/src/helpers/connectivity_provider.dart
@@ -1,7 +1,11 @@
+import 'dart:async';
+import 'dart:developer';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/address_model.dart';
-import '../services/connectivity_service.dart';
+
+import 'package:internet_connection_checker_plus/internet_connection_checker_plus.dart' ;
 
 /// This class listens to connectivity changes and notifies its listeners.
 class ConnectivityProvider extends StreamNotifier<ConnectivityStatus> {
@@ -11,12 +15,36 @@ class ConnectivityProvider extends StreamNotifier<ConnectivityStatus> {
   @override
   Stream<ConnectivityStatus> build() {
     return ref
-        .watch(connectivityServiceProvider(ConnectivityServiceParams(
-          interval: const Duration(seconds: 10),
-        )))
-        .onStatusChange;
+        .watch(connectivityStreamProvider.future).asStream();
   }
 }
+
+/// transform the stream of connectivity status to a stream of [ConnectivityStatus].
+///
+/// This provider listens to the stream of connectivity status and transforms it to a stream of [ConnectivityStatus].
+final connectivityStreamProvider = StreamProvider<ConnectivityStatus>((ref) {
+  final internet = InternetConnectionCheckerPlus();
+  return internet.onStatusChange.transform(
+    StreamTransformer.fromHandlers(
+      handleDone: (sink) {
+        sink.close();
+      },
+      handleError: (error, stackTrace, sink) {
+        log('[internet_connectivity]: $error',);
+        sink.add(ConnectivityStatus.disconnected);
+      },
+      handleData: (status, sink) {
+        if (status == InternetConnectionStatus.connected) {
+          sink.add(ConnectivityStatus.connected);
+        } else {
+          sink.add(ConnectivityStatus.disconnected);
+        }
+      },
+    ),
+  );
+});
+
+
 /// Global provider for [ConnectivityProvider].
 /// This provider allows access to the connectivity status stream from anywhere in the app.
 final connectivityProvider =

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -111,6 +111,9 @@ dependencies:
   disk_space: ^0.2.1
 
   equatable: ^2.0.5
+
+  # internet connectivity checker
+  internet_connection_checker_plus: ^1.0.1
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
📝 **Summary**
---
**This PR adapts the connectivity service of the app to use the `internet_connection_checker_plus` package, which provides more robust connectivity checking by not only checking for network connectivity, but also pinging the internet to ensure the app can actually access external resources.**

**Description**
---
This PR addresses the issue of the app's current connectivity service, which only checks for network connectivity without verifying the app's ability to access the internet. The changes made in this PR replace the existing `ConnectivityService` with a new implementation that uses the `internet_connection_checker_plus` package.

The new `ConnectivityProvider` now listens to the stream of connectivity status from the `internet_connection_checker_plus` package and transforms it into a stream of `ConnectivityStatus` values, which can be consumed by the rest of the app.

This approach provides a more reliable way to determine the app's connectivity status, as it not only checks for network availability but also verifies the app's ability to access external resources by pinging the internet.

**Tests**
---
🧪 **Use case 1: Verify connectivity status changes**
---
💬 **Description:** Ensure that the `ConnectivityProvider` correctly emits `ConnectivityStatus.connected` when the device has internet connectivity and `ConnectivityStatus.disconnected` when the device loses internet connectivity.

📷 **Screenshots or GIFs (if applicable):**
<screenshot or GIF showing the connectivity status changes>

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).