### PR TITLE
fix: handle adhan audio cutting off for Fajr prayer

### DIFF
--- a/lib/src/pages/home/sub_screens/AdhanSubScreen.dart
+++ b/lib/src/pages/home/sub_screens/AdhanSubScreen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:mawaqit/i18n/l10n.dart';
+import 'package:mawaqit/main.dart';
 import 'package:mawaqit/src/helpers/RelativeSizes.dart';
 import 'package:mawaqit/src/helpers/mawaqit_icons_icons.dart';
 import 'package:mawaqit/src/helpers/repaint_boundaries.dart';
@@ -39,7 +40,8 @@ class _AdhanSubScreenState extends State<AdhanSubScreen> {
     final mosqueManager = context.read<MosqueManager>();
     final mosqueConfig = mosqueManager.mosqueConfig;
     audioManager = context.read<AudioManager>();
-    final duration = mosqueManager.getAdhanDuration();
+    final isFajrPray = mosqueManager.salahIndex == 0;
+    final duration = mosqueManager.getAdhanDuration(isFajrPray);
 
     Future.delayed(Duration(minutes: 5), () {
       closeAdhanScreen();

--- a/lib/src/pages/home/workflow/salah_workflow.dart
+++ b/lib/src/pages/home/workflow/salah_workflow.dart
@@ -72,8 +72,8 @@ class _SalahWorkflowScreenState extends State<SalahWorkflowScreen> {
     final now = mosqueManger.mosqueDate();
     final currentSalahTime = mosqueManger.actualTimes()[currentSalah];
     final currentIqamaTime = mosqueManger.actualIqamaTimes()[currentSalah];
-
-    final adhanEndTime = currentSalahTime.add(mosqueManger.getAdhanDuration());
+    final isFajrPray = mosqueManger.salahIndex == 0;
+    final adhanEndTime = currentSalahTime.add(mosqueManger.getAdhanDuration(isFajrPray));
     final adhanDuaaEndTime = adhanEndTime.add(Duration(seconds: 35));
     final iqamaEndTime = currentIqamaTime.add(Duration(minutes: 1));
     final salahTime = mosqueManger.mosqueConfig!.duaAfterPrayerShowTimes[currentSalah];

--- a/lib/src/services/mixins/audio_mixin.dart
+++ b/lib/src/services/mixins/audio_mixin.dart
@@ -6,9 +6,13 @@ import 'package:mawaqit/src/models/mosqueConfig.dart';
 mixin AudioMixin on ChangeNotifier {
   abstract MosqueConfig? mosqueConfig;
 
-  Duration getAdhanDuration() {
+  Duration getAdhanDuration(bool isFajrPray) {
     String? adhanName = mosqueConfig?.adhanVoice;
     Duration duration = Duration(seconds: mosqueConfig!.adhanDuration!);
+
+    if(isFajrPray && adhanName != null){
+      adhanName = adhanName + '-fajr';
+    }
 
     switch (adhanName) {
       case "adhan-afassy":
@@ -43,7 +47,7 @@ mixin AudioMixin on ChangeNotifier {
         duration = Duration(seconds: 185 + 5);
         break;
     }
-    log('AudioMixin: Adhan duration: $duration');
+
     return duration;
   }
 }


### PR DESCRIPTION
📝 **Summary**
---
Handles the issue of adhan audio cutting off in the middle for Fajr prayer

**This solve issue: #1100**

**Description**
---
This PR addresses the issue where the adhan audio was cutting off in the middle during the Fajr prayer. It introduces the following changes:

1. In `AdhanSubScreen.dart`, a flag `isFajrPray` is added to check if the current salah index is 0 (Fajr prayer). The `getAdhanDuration` function is called with this flag to determine the appropriate duration.

2. In `salah_workflow.dart`, the `isFajrPray` flag is also used when calling `getAdhanDuration` to calculate the `adhanEndTime`.

3. In `audio_mixin.dart`, the `getAdhanDuration` function is modified to handle the Fajr prayer case. If the `isFajrPray` flag is true and the `adhanName` is not null, the '-fajr' suffix is appended to the `adhanName`.

**Tests**
---
🧪 **Use case 1**
---
💬 **Description:** Test the Fajr prayer adhan playback to ensure the audio does not cut off in the middle.

📷 **Screenshots or GIFs (if applicable):** [Provide any relevant screenshots or GIFs demonstrating the successful test case]

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).