### PR TITLE
fix: cancel debug walkthrough

### DIFF
--- a/lib/src/pages/developer/DeveloperScreen.dart
+++ b/lib/src/pages/developer/DeveloperScreen.dart
@@ -109,6 +109,7 @@ class _DeveloperScreenState extends State<DeveloperScreen> {
     walkThrowScreensSubscription?.cancel();
     setState(() {
       walkThrowScreensSubscription = null;
+      forcedScreen = null;  // clear the forcedScreen when canceling the walkthrough
     });
   }
 
@@ -135,6 +136,11 @@ class _DeveloperScreenState extends State<DeveloperScreen> {
     }
   }
 
+  @override
+  void dispose() {
+    cancelWalkThrowScreens();
+    super.dispose();
+  }
   @override
   Widget build(BuildContext context) {
     context.watch<MosqueManager>();


### PR DESCRIPTION
## **This PR for issue** : #986 
## 💬 **Description:**

This pull request resolves an issue where the debug walkthrough was not being canceled correctly when the DeveloperScreen was disposed. This caused the walkthrough to continue running in the background, potentially leading to unexpected behavior or memory leaks.

## Changes

- Added a call to `cancelWalkThrowScreens()` in the `dispose` method of the DeveloperScreen.
- Updated the `cancelWalkThrowScreens()` method to also set `forcedScreen` to `null` when canceling the walkthrough.

## Testing

- Manually tested the debug walkthrough functionality by starting and canceling the walkthrough on the DeveloperScreen.
- Verified that the walkthrough is properly canceled when the DeveloperScreen is disposed.
- Checked for any memory leaks or unexpected behavior after disposing the DeveloperScreen.

## Screenshots (if applicable)

N/A

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).
