### PR TITLE
Fix Import Conflicts and Update Dependencies in `SettingScreen.dart`

### DIFF
--- a/lib/src/pages/SettingScreen.dart
+++ b/lib/src/pages/SettingScreen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart' show AsyncValueX, ConsumerWidget, Ref, WidgetRef;
+import 'package:flutter_riverpod/flutter_riverpod.dart' show AsyncValueX, ConsumerWidget, WidgetRef, Consumer;
 import 'package:mawaqit/i18n/l10n.dart';
 import 'package:mawaqit/src/helpers/AppRouter.dart';
 import 'package:mawaqit/src/helpers/connectivity_provider.dart';
@@ -13,7 +13,7 @@ import 'package:mawaqit/src/services/mosque_manager.dart';
 import 'package:mawaqit/src/services/theme_manager.dart';
 import 'package:mawaqit/src/services/user_preferences_manager.dart';
 import 'package:mawaqit/src/widgets/ScreenWithAnimation.dart';
-import 'package:provider/provider.dart';
+import 'package:provider/provider.dart' hide Consumer;
 import 'package:sizer/sizer.dart';
 
 import '../../i18n/AppLanguage.dart';
@@ -143,21 +143,23 @@ class SettingScreen extends ConsumerWidget {
                       );
                     },
                   ),
-                  riverpod.Consumer(builder: (context, ref, child) {
-                    return _SettingSwitchItem(
-                      title: S.of(context).automaticUpdate,
-                      subtitle: S.of(context).automaticUpdateDescription,
-                      icon: Icon(Icons.update, size: 35),
-                      onChanged: (value) {
-                        logger.d('setting: disable the update $value');
-                        ref.read(appUpdateProvider.notifier).toggleAutoUpdateChecking();
-                      },
-                      value: ref.watch(appUpdateProvider).maybeWhen(
-                            orElse: () => false,
-                            data: (data) => data.isAutoUpdateChecking,
-                          ),
-                    );
-                  }),
+                  Consumer(
+                    builder: (context, ref, child) {
+                      return _SettingSwitchItem(
+                        title: S.of(context).automaticUpdate,
+                        subtitle: S.of(context).automaticUpdateDescription,
+                        icon: Icon(Icons.update, size: 35),
+                        onChanged: (value) {
+                          logger.d('setting: disable the update $value');
+                          ref.read(appUpdateProvider.notifier).toggleAutoUpdateChecking();
+                        },
+                        value: ref.watch(appUpdateProvider).maybeWhen(
+                              orElse: () => false,
+                              data: (data) => data.isAutoUpdateChecking,
+                            ),
+                      );
+                    },
+                  ),
                   SizedBox(height: 30),
                   Divider(),
                   SizedBox(height: 10),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -119,7 +119,7 @@ dependencies:
   # app update
   upgrader: ^6.5.0
   open_store: ^0.5.0
-  
+
   # internet connectivity checker
   internet_connection_checker_plus: ^1.0.1
 
@@ -130,6 +130,7 @@ dev_dependencies:
   # to get unused packages run
   # flutter pub run dependency_validator
   dependency_validator:
+  build_runner: ^2.1.4
   http_mock_adapter: ^0.6.1
   flutter_lints: ^3.0.2
 # For information on the generic Dart part of this file, see the


### PR DESCRIPTION
### Summary
This pull request addresses issues related to import conflicts and outdated dependencies in the `SettingScreen.dart` file. It also includes an update to the `pubspec.yaml` to include a new version of `build_runner`.

### Changes
1. **SettingScreen.dart**
   - Updated imports to resolve conflicts between `flutter_riverpod` and `provider` packages by using selective imports and the `hide` keyword.
   - Modified the use of `Consumer` to adhere to the latest best practices recommended by `flutter_riverpod`.

2. **pubspec.yaml**
   - Added the `build_runner` package to improve the build process.
   - Made minor adjustments to the spacing to enhance file readability and maintain consistency.
