### PR TITLE
fix:  Mosque UUID Fetching in Announcement System

### DIFF
--- a/lib/src/data/repository/announcement_impl.dart
+++ b/lib/src/data/repository/announcement_impl.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:developer';
 
 import 'package:dio/dio.dart';
@@ -7,6 +8,7 @@ import 'package:mawaqit/src/models/address_model.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../const/constants.dart';
+import '../../helpers/SharedPref.dart';
 import '../../helpers/connectivity_provider.dart';
 import '../../models/announcement.dart';
 import '../data_source/announcement_local_data_source.dart';
@@ -29,7 +31,7 @@ class AnnouncementImpl implements AnnouncementRepository {
   @override
   Stream<List<Announcement>> getAnnouncementsStream([String? mosqueUUID]) {
     /// get the uuid of the mosque
-    mosqueUUID ??= _sharedPreferences.getString(MosqueManagerConstant.kMosqueUUID);
+    mosqueUUID ??= jsonDecode(_sharedPreferences.getString('mosqueUUId') ?? '{}');
 
     if (mosqueUUID == null || mosqueUUID.isEmpty) {
       throw Exception('No mosque id found');
@@ -48,7 +50,9 @@ class AnnouncementImpl implements AnnouncementRepository {
   @override
   Future<List<Announcement>> getAnnouncements([String? mosqueUUID]) async {
     /// get the uuid of the mosque
-    mosqueUUID ??= _sharedPreferences.getString(MosqueManagerConstant.kMosqueUUID);
+    mosqueUUID ??= jsonDecode(_sharedPreferences.getString('mosqueUUId') ?? '{}');
+
+    log('announcement: AnnouncementImpl: getAnnouncements - mosqueId: $mosqueUUID');
 
     if (mosqueUUID == null || mosqueUUID.isEmpty) {
       throw Exception('No mosque id found');

--- a/lib/src/pages/home/sub_screens/AnnouncementScreen.dart
+++ b/lib/src/pages/home/sub_screens/AnnouncementScreen.dart
@@ -228,9 +228,9 @@ class _VideoAnnouncementState extends ConsumerState<_VideoAnnouncement> {
         forceHD: true,
       ),
     )..addListener(() {
-      if (_controller.value.isReady && _controller.value.isPlaying) {
-        _startTimeoutTimer();
-      }
+        if (_controller.value.isReady && _controller.value.isPlaying) {
+          _startTimeoutTimer();
+        }
       });
 
     super.initState();

--- a/lib/src/services/mosque_manager.dart
+++ b/lib/src/services/mosque_manager.dart
@@ -120,7 +120,6 @@ class MosqueManager extends ChangeNotifier with WeatherMixin, AudioMixin, Mosque
   }
 
   Future<void> loadFromLocale() async {
-    // mosqueId = await sharedPref.read('mosqueId');
     mosqueUUID = await sharedPref.read('mosqueUUId');
     if (mosqueUUID != null) {
       await fetchMosque(mosqueUUID!);

--- a/lib/src/state_management/workflow/announcement_workflow/announcement_workflow_notifier.dart
+++ b/lib/src/state_management/workflow/announcement_workflow/announcement_workflow_notifier.dart
@@ -133,9 +133,13 @@ class AnnouncementWorkflowNotifier extends AutoDisposeAsyncNotifier<Announcement
           status: AnnouncementWorkflowStatus.playing,
         ),
       );
-      await Future.delayed(Duration(seconds: 5));
-      final duration = ref.read(videoProvider);
-      await Future.delayed(duration);
+      bool isPlaying = ref.read(videoProvider);
+      log('announcement: AnnouncementWorkflowNotifier: _displayAnnouncement: isPlaying $isPlaying');
+      while(isPlaying){
+        await Future.delayed(Duration(seconds: 1));
+        isPlaying = ref.read(videoProvider);
+      }
+      ref.read(videoProvider.notifier).state = true;
     } else if (announcement.duration != null && link == null) {
       // link checks if it is a video or not
       log('announcement: AnnouncementWorkflowNotifier: _displayAnnouncement: text ${announcement.id}');

--- a/lib/src/state_management/workflow/announcement_workflow/announcement_workflow_notifier.dart
+++ b/lib/src/state_management/workflow/announcement_workflow/announcement_workflow_notifier.dart
@@ -135,7 +135,7 @@ class AnnouncementWorkflowNotifier extends AutoDisposeAsyncNotifier<Announcement
       );
       bool isPlaying = ref.read(videoProvider);
       log('announcement: AnnouncementWorkflowNotifier: _displayAnnouncement: isPlaying $isPlaying');
-      while(isPlaying){
+      while (isPlaying) {
         await Future.delayed(Duration(seconds: 1));
         isPlaying = ref.read(videoProvider);
       }


### PR DESCRIPTION
📝 **Summary**
---
**This PR addresses the issue of mismatched variable names used for fetching mosque details, specifically correcting the variable name from `mosqueUUID` to `mosqueUUId` in the announcement management system.**

**Description**
---
This change updates the variable references in the `announcement_impl.dart` and `mosque_manager.dart` files to use `mosqueUUId` instead of `mosqueUUID`. This fix is crucial for the correct fetching of the mosque's UUID from shared preferences, ensuring that the application handles data consistently and correctly. The update includes JSON decoding of the stored UUID and logging enhancements for better traceability of data handling.

**Tests**
---
🧪 **Use case 1**
---
💬 **Description:**
Verify that the mosque UUID is correctly fetched from shared preferences and used in fetching announcements. This can be tested by simulating the retrieval process and checking if announcements are accurately fetched based on the correct mosque UUID.

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).
