### PR TITLE
refactor: remove the filter of the time in the `announcement`

### DIFF
--- a/lib/src/state_management/workflow/announcement_workflow/announcement_workflow_notifier.dart
+++ b/lib/src/state_management/workflow/announcement_workflow/announcement_workflow_notifier.dart
@@ -55,10 +55,7 @@ class AnnouncementWorkflowNotifier extends AutoDisposeAsyncNotifier<Announcement
   ///
   /// @param announcements The list of announcements to be displayed in a linear manner.
   Future<void> _startLinearAnnouncement(List<Announcement> announcements, bool isPlayingVideo) async {
-    log('announcement: AnnouncementWorkflowNotifier: _startLinearAnnouncement');
-    announcements =
-        announcements.where((element) => TimeHelper.isBetweenStartAndEnd(element.startDate, element.endDate)).toList();
-    log('announcement: AnnouncementWorkflowNotifier: initial $announcements');
+    log('announcement: AnnouncementWorkflowNotifier: _startLinearAnnouncement $announcements');
     for (int i = 0; i < announcements.length; i++) {
       if (!_startLinear) return;
       final announcementMode = await _getAnnouncementMode();
@@ -81,9 +78,6 @@ class AnnouncementWorkflowNotifier extends AutoDisposeAsyncNotifier<Announcement
   ///
   /// @param announcements The list of announcements to be displayed in a repeated manner.
   Future<void> _startRepeatedAnnouncement(List<Announcement> announcements, bool isPlayingVideo) async {
-    log('announcement: AnnouncementWorkflowNotifier: _startRepeatedAnnouncement');
-    announcements =
-        announcements.where((element) => TimeHelper.isBetweenStartAndEnd(element.startDate, element.endDate)).toList();
     log('announcement: AnnouncementWorkflowNotifier: _startRepeatedAnnouncement initial $announcements');
     int index = 0;
 
@@ -117,7 +111,7 @@ class AnnouncementWorkflowNotifier extends AutoDisposeAsyncNotifier<Announcement
   }
 
   /// [_displayAnnouncement] displays the provided announcement. if it is video it will play
-  /// the video based on videoProvider to get the duration of the video.
+  /// the video based\ on videoProvider to get the duration of the video.
   /// if it is text it will display the text for the provided duration or image
   Future<void> _displayAnnouncement(Announcement announcement, bool isPlayingVideo) async {
     final link = announcement.video;


### PR DESCRIPTION
📝 **Summary**
---
**This PR for issue**  : #1128 
Refactors the `AnnouncementWorkflowNotifier` to remove the time-based filtering from the announcement display logic.

**Description**
---
This change simplifies the process of handling announcements by removing the time filter that restricted announcements to their start and end times. Now, all provided announcements are considered eligible for display without time constraints. This modification is expected to streamline the display process and reduce the complexity of the code.

**Tests**
---
🧪 **Use case 1**
---
💬 **Description:**
Tested the announcements display in both linear and repeated modes to ensure that all announcements are now considered without time filtering. Verified that announcements outside their previously defined time frames are displayed correctly.

📷 **Screenshots or GIFs (if applicable):**
*(Screenshots or GIFs showing the announcement display without time filtering can be added here.)*

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).
