### PR TITLE
refactor: update app pop up

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -197,7 +197,7 @@
   "seeMore": "See more",
   "whatIsNew": "What's new",
   "update": "Update",
-  "automaticUpdate": "Automatic update",
-  "automaticUpdateDescription": "Enable automatic update to get the latest features and improvements",
+  "automaticUpdate": "Notify update",
+  "automaticUpdateDescription": "Enable notify update to receive the latest features and improvements",
   "later": "Later"
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -198,5 +198,6 @@
   "whatIsNew": "What's new",
   "update": "Update",
   "automaticUpdate": "Automatic update",
-  "automaticUpdateDescription": "Enable automatic update to get the latest features and improvements"
+  "automaticUpdateDescription": "Enable automatic update to get the latest features and improvements",
+  "later": "Later"
 }

--- a/lib/src/pages/times/normal_home/landscape_normal_home.dart
+++ b/lib/src/pages/times/normal_home/landscape_normal_home.dart
@@ -75,7 +75,7 @@ class _LandscapeNormalHomeState extends riverpod.ConsumerState<LandscapeNormalHo
   @override
   Widget build(BuildContext context) {
     ref.listen(appUpdateProvider, (previous, next) {
-      if (next.hasValue && !next.isReloading && next.value!.appUpdateStatus == AppUpdateStatus.updateAvailable){
+      if (next.hasValue && !next.isReloading && next.value!.appUpdateStatus == AppUpdateStatus.updateAvailable) {
         log('update available ${next.value} || ${next.isReloading} || ${next.isLoading} || ${next.hasValue}');
         showUpdateAlert(
           context: context,

--- a/lib/src/pages/times/normal_home/landscape_normal_home.dart
+++ b/lib/src/pages/times/normal_home/landscape_normal_home.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:developer';
 
 import 'package:collection/collection.dart';
 import 'package:flutter/widgets.dart';
@@ -52,7 +53,7 @@ class _LandscapeNormalHomeState extends riverpod.ConsumerState<LandscapeNormalHo
   @override
   void initState() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      _updateTimer = Timer.periodic(Duration(minutes: 25), (timer) {
+      _updateTimer = Timer.periodic(Duration(minutes: 1), (timer) {
         final mosque = Provider.of<MosqueManager>(context, listen: false);
         final today = mosque.useTomorrowTimes ? AppDateTime.tomorrow() : AppDateTime.now();
         final prays = mosque.times?.dayTimesStrings(today);
@@ -74,8 +75,8 @@ class _LandscapeNormalHomeState extends riverpod.ConsumerState<LandscapeNormalHo
   @override
   Widget build(BuildContext context) {
     ref.listen(appUpdateProvider, (previous, next) {
-      if (next.value!.appUpdateStatus == AppUpdateStatus.updateAvailable &&
-          next.value!.message != previous!.value!.message) {
+      if (next.hasValue && !next.isReloading && next.value!.appUpdateStatus == AppUpdateStatus.updateAvailable){
+        log('update available ${next.value} || ${next.isReloading} || ${next.isLoading} || ${next.hasValue}');
         showUpdateAlert(
           context: context,
           duration: Duration(seconds: 30),

--- a/lib/src/pages/times/normal_home/landscape_normal_home.dart
+++ b/lib/src/pages/times/normal_home/landscape_normal_home.dart
@@ -53,7 +53,7 @@ class _LandscapeNormalHomeState extends riverpod.ConsumerState<LandscapeNormalHo
   @override
   void initState() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      _updateTimer = Timer.periodic(Duration(minutes: 1), (timer) {
+      _updateTimer = Timer.periodic(Duration(minutes: 25), (timer) {
         final mosque = Provider.of<MosqueManager>(context, listen: false);
         final today = mosque.useTomorrowTimes ? AppDateTime.tomorrow() : AppDateTime.now();
         final prays = mosque.times?.dayTimesStrings(today);

--- a/lib/src/pages/times/normal_home/portrait_normal_home.dart
+++ b/lib/src/pages/times/normal_home/portrait_normal_home.dart
@@ -76,7 +76,7 @@ class _PortraitNormalHomeState extends riverpod.ConsumerState<PortraitNormalHome
   @override
   Widget build(BuildContext context) {
     ref.listen(appUpdateProvider, (previous, next) {
-      if (next.hasValue && !next.isReloading && next.value!.appUpdateStatus == AppUpdateStatus.updateAvailable){
+      if (next.hasValue && !next.isReloading && next.value!.appUpdateStatus == AppUpdateStatus.updateAvailable) {
         showUpdateAlert(
           context: context,
           duration: Duration(seconds: 30),

--- a/lib/src/pages/times/normal_home/portrait_normal_home.dart
+++ b/lib/src/pages/times/normal_home/portrait_normal_home.dart
@@ -76,8 +76,7 @@ class _PortraitNormalHomeState extends riverpod.ConsumerState<PortraitNormalHome
   @override
   Widget build(BuildContext context) {
     ref.listen(appUpdateProvider, (previous, next) {
-      if (next.value!.appUpdateStatus == AppUpdateStatus.updateAvailable &&
-          next.value!.message != previous!.value!.message) {
+      if (next.hasValue && !next.isReloading && next.value!.appUpdateStatus == AppUpdateStatus.updateAvailable){
         showUpdateAlert(
           context: context,
           duration: Duration(seconds: 30),

--- a/lib/src/pages/times/turkish_home/landscape_turkish_home.dart
+++ b/lib/src/pages/times/turkish_home/landscape_turkish_home.dart
@@ -74,8 +74,7 @@ class _LandScapeTurkishHomeState extends riverpod.ConsumerState<LandScapeTurkish
   @override
   Widget build(BuildContext context) {
     ref.listen(appUpdateProvider, (previous, next) {
-      if (next.value!.appUpdateStatus == AppUpdateStatus.updateAvailable &&
-          next.value!.message != previous!.value!.message) {
+      if (next.hasValue && !next.isReloading && next.value!.appUpdateStatus == AppUpdateStatus.updateAvailable){
         showUpdateAlert(
           context: context,
           onDismissPressed: () => ref.read(appUpdateProvider.notifier).dismissUpdate(),

--- a/lib/src/pages/times/turkish_home/landscape_turkish_home.dart
+++ b/lib/src/pages/times/turkish_home/landscape_turkish_home.dart
@@ -74,7 +74,7 @@ class _LandScapeTurkishHomeState extends riverpod.ConsumerState<LandScapeTurkish
   @override
   Widget build(BuildContext context) {
     ref.listen(appUpdateProvider, (previous, next) {
-      if (next.hasValue && !next.isReloading && next.value!.appUpdateStatus == AppUpdateStatus.updateAvailable){
+      if (next.hasValue && !next.isReloading && next.value!.appUpdateStatus == AppUpdateStatus.updateAvailable) {
         showUpdateAlert(
           context: context,
           onDismissPressed: () => ref.read(appUpdateProvider.notifier).dismissUpdate(),

--- a/lib/src/pages/times/turkish_home/portrait_turkish_home.dart
+++ b/lib/src/pages/times/turkish_home/portrait_turkish_home.dart
@@ -75,7 +75,7 @@ class _PortraitTurkishHomeState extends riverpod.ConsumerState<PortraitTurkishHo
   @override
   Widget build(BuildContext context) {
     ref.listen(appUpdateProvider, (previous, next) {
-      if (next.hasValue && !next.isReloading && next.value!.appUpdateStatus == AppUpdateStatus.updateAvailable){
+      if (next.hasValue && !next.isReloading && next.value!.appUpdateStatus == AppUpdateStatus.updateAvailable) {
         showUpdateAlert(
           context: context,
           duration: Duration(seconds: 30),

--- a/lib/src/pages/times/turkish_home/portrait_turkish_home.dart
+++ b/lib/src/pages/times/turkish_home/portrait_turkish_home.dart
@@ -75,8 +75,7 @@ class _PortraitTurkishHomeState extends riverpod.ConsumerState<PortraitTurkishHo
   @override
   Widget build(BuildContext context) {
     ref.listen(appUpdateProvider, (previous, next) {
-      if (next.value!.appUpdateStatus == AppUpdateStatus.updateAvailable &&
-          next.value!.message != previous!.value!.message) {
+      if (next.hasValue && !next.isReloading && next.value!.appUpdateStatus == AppUpdateStatus.updateAvailable){
         showUpdateAlert(
           context: context,
           duration: Duration(seconds: 30),

--- a/lib/src/widgets/show_update_alert.dart
+++ b/lib/src/widgets/show_update_alert.dart
@@ -25,28 +25,32 @@ Future<void> showUpdateAlert({
         forwardAnimationCurve: Curves.easeInCirc,
         reverseAnimationCurve: Curves.bounceIn,
         position: FlashPosition.bottom,
-        icon: Icon(Icons.new_releases),
+        icon: Icon(Icons.download_rounded),
         title: Text(localization.updateAvailable),
         actions: [
+          TextButton(
+            onPressed: onPressed,
+            child: Text(localization.update),
+          ),
+          TextButton(
+            onPressed: () {
+              controller.dismiss();
+              _showUpdateVersionDialog(
+                context,
+                content,
+                onPressed,
+                onDismissPressed,
+              );
+            },
+            child: Text(localization.seeMore),
+          ),
           TextButton(
             onPressed: () {
               controller.dismiss();
               onDismissPressed();
             },
-            child: Text(localization.cancel),
+            child: Text(localization.later),
           ),
-          TextButton(onPressed: onPressed, child: Text(localization.ok)),
-          TextButton(
-              onPressed: () {
-                controller.dismiss();
-                _showUpdateVersionDialog(
-                  context,
-                  content,
-                  onPressed,
-                  onDismissPressed,
-                );
-              },
-              child: Text(localization.seeMore)),
         ],
         content: Text(title),
       );
@@ -80,7 +84,7 @@ Future<void> _showUpdateVersionDialog(
                 Navigator.of(context).pop();
               }),
           TextButton(
-              child: Text(l10n.cancel),
+              child: Text(l10n.later),
               onPressed: () {
                 onDismissPressed();
                 Navigator.of(context).pop();


### PR DESCRIPTION
📝 **Summary**
---
**issue number**: #1130 
**This PR addresses UI and behavior updates for the app update notification dialog, ensuring a more efficient and user-friendly interaction.**

**Description**
---
- Changed the position of the buttons in the update dialog to `update | see more | later`.
- Updated the icon for the dialog to a more relevant `download_rounded` icon.
- Removed duplicated state emissions in Riverpod by simplifying state updates within the `AppUpdateNotifier`.
- Capitalized the first letter of each button text for consistency.
- Changed the in-app update settings text from `automatic` to `notify` for clearer user communication.

**Tests**
---
🧪 **Use case 1**
---
💬 **Description:**
Tested the new button arrangement and icon change in the update dialog. Ensured that the dialog appears as expected with the correct sequence and updated icon.

🧪 **Use case 2**
---
💬 **Description:**
Verified the removal of duplicated state emissions by checking the app's performance and ensuring no unnecessary re-renders occur.

🧪 **Use case 3**
---
💬 **Description:**
Tested the new timing for displaying the update notification. Confirmed the popup appears exactly 30 minutes after the specified Iqama time.

🧪 **Use case 4**
---
💬 **Description:**
Ensured that changing the in-app update settings text updates appropriately and that the setting toggles between `notify` and its previous state effectively.

📷 **Screenshots or GIFs (if applicable):**
*Screenshots of the new update dialog and settings option.*

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).
