### PR TITLE
Fix/ add changes not sent for review to codemagic file

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -110,3 +110,4 @@ workflows:
       google_play:
         credentials: $GCLOUD_SERVICE_ACCOUNT_CREDENTIALS
         track: $GOOGLE_PLAY_TRACK
+        changes_not_sent_for_review: true


### PR DESCRIPTION
This PR fixes the error when publishing the new built artifact with codemagic to google Play.

`Google Play failed to upload artefacts. Changes cannot be sent for review automatically. Please set the query parameter changesNotSentForReview to true. Once committed, the changes in this edit can be sent for review from the Google Play Console UI.: {
    "error": {
        "code": 400,
        "message": "Changes cannot be sent for review automatically. Please set the query parameter changesNotSentForReview to true. Once committed, the changes in this edit can be sent for review from the Google Play Console UI.",
        "status": "INVALID_ARGUMENT"
    }
}`