### PR TITLE
fix:  Fixing the bug that causes the Adhan screen to be skipped when the time is set.

### DIFF
--- a/lib/src/pages/home/sub_screens/AdhanSubScreen.dart
+++ b/lib/src/pages/home/sub_screens/AdhanSubScreen.dart
@@ -61,8 +61,6 @@ class _AdhanSubScreenState extends State<AdhanSubScreen> {
         },
         useFajrAdhan: mosqueManager.salahIndex == 0,
       );
-    } else {
-      closeAdhanScreen();
     }
     super.initState();
   }


### PR DESCRIPTION
📝 **Summary**
---
**This PR for issue**: Fixing the bug that causes the Adhan screen to be skipped when the time is set.

**Description**
---
This pull request addresses the issue where the Adhan screen was being skipped under certain conditions. The problem was traced back to the `AdhanSubScreen.dart` file, where the `closeAdhanScreen` method was being called erroneously. By removing this call, we ensure that the Adhan screen displays correctly when the time is set.

**Tests**
---
🧪 **Use case 1**
---
💬 **Description:**
1. Set the time for an Adhan.
2. Observe that the Adhan screen appears as expected without being skipped.

📷 **Screenshots or GIFs (if applicable):**
N/A

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).