### PR TITLE
fix: showing Quran after downloading it 

### DIFF
--- a/lib/src/state_management/quran/download_quran/download_quran_notifier.dart
+++ b/lib/src/state_management/quran/download_quran/download_quran_notifier.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mawaqit/src/data/repository/quran/quran_download_impl.dart';
 import 'package:mawaqit/src/domain/error/quran_exceptions.dart';
 import 'package:mawaqit/src/state_management/quran/download_quran/download_quran_state.dart';
+import 'package:mawaqit/src/state_management/quran/reading/quran_reading_notifer.dart';
 import 'package:path_provider/path_provider.dart';
 
 class DownloadQuranNotifier extends AsyncNotifier<DownloadQuranState> {
@@ -88,8 +89,10 @@ class DownloadQuranNotifier extends AsyncNotifier<DownloadQuranState> {
 
         // Delete the downloaded ZIP file
         await downloadQuranRepoImpl.deleteZipFile(remoteVersion);
+        Future.microtask(() {
+          ref.invalidate(quranReadingNotifierProvider);
+        });        // Notify the success state with the new version
 
-        // Notify the success state with the new version
         state = AsyncData(
           Success(
             version: remoteVersion,


### PR DESCRIPTION
📝 **Summary**
---
**Description**
---
This pull request addresses an issue where the Quran wasn't showing immediately after being downloaded. The fix involves using `Future.microtask()` to invalidate the `quranReadingNotifierProvider` after the download and extraction process is complete. This ensures that the UI is updated properly to reflect the newly downloaded Quran content.

**Tests**
---
🧪 **Use case 1**
---
💬 **Description:**
1. Initiate a Quran download
2. Wait for the download and extraction to complete
3. Verify that the Quran content is immediately visible and accessible after the process finishes

📷 **Screenshots or GIFs (if applicable):**

![fix_pr](https://github.com/user-attachments/assets/3d4b730a-a7b0-4960-ba6c-90d964b0642f)

**Changes Made**
---
- Added `Future.microtask()` to defer the invalidation of `quranReadingNotifierProvider`
- This change ensures that the provider is invalidated after the current execution cycle, preventing potential state conflicts

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).

**Additional Notes**
---
This fix should resolve the issue of the Quran not being immediately visible after download. It's a minor change but should significantly improve the user experience by ensuring that the newly downloaded content is accessible right away.