### PR TITLE
fix: selection node in the `QuranModeSelection` screen

### DIFF
--- a/lib/src/pages/quran/page/quran_mode_selection_screen.dart
+++ b/lib/src/pages/quran/page/quran_mode_selection_screen.dart
@@ -82,14 +82,20 @@ class _QuranModeSelectionState extends ConsumerState<QuranModeSelection> {
           LogicalKeySet(LogicalKeyboardKey.select): const ActivateIntent(),
         },
         child: QuranBackground(
-          appBar: AppBar(
-            backgroundColor: Colors.transparent,
-            elevation: 0,
-            systemOverlayStyle: SystemUiOverlayStyle.light,
-          ),
           screen: Column(
             mainAxisAlignment: MainAxisAlignment.start,
             children: [
+              Container(
+                alignment: AlignmentDirectional.centerStart,
+                child: ExcludeFocus(
+                  child: IconButton(
+                    icon: Icon(Icons.arrow_back),
+                    onPressed: () {
+                      Navigator.pop(context);
+                    },
+                  ),
+                ),
+              ),
               SizedBox(height: 10.h),
               SizedBox(height: 40),
               Row(


### PR DESCRIPTION
📝 **Summary**
---
This PR addresses an issue with the selection node in the `QuranModeSelection` screen.

**Description**
---
The following changes have been made:
- Added a back button to navigate to the previous screen.
- Ensured the focus nodes are properly managed for `QuranModeSelection`.

**Tests**
---
🧪 **Use case 1**
---
💬 **Description:**
1. Run the application.
2. Navigate to the `QuranModeSelection` screen.
3. Use the arrow keys to switch between reading and listening modes.
4. Press the select button to navigate to the corresponding screen.
5. Click the back button to return to the previous screen.

📷 **Screenshots or GIFs (if applicable):**

![quran_selection](https://github.com/user-attachments/assets/07ce3183-daac-4801-9d96-40e43babe87a)

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).