### PR TITLE
fix: add directionality for the surah selection

### DIFF
--- a/lib/src/pages/quran/page/surah_selection_screen.dart
+++ b/lib/src/pages/quran/page/surah_selection_screen.dart
@@ -137,6 +137,7 @@ class _SurahSelectionScreenState extends ConsumerState<SurahSelectionScreen> {
 
   void _handleKeyEvent(RawKeyEvent event) {
     final surahs = ref.read(quranNotifierProvider).maybeWhen(orElse: () => [], data: (data) => data.suwar);
+    final textDirection = Directionality.of(context);
 
     if (event is RawKeyDownEvent) {
       log('Key pressed: ${event.logicalKey}');
@@ -145,12 +146,20 @@ class _SurahSelectionScreenState extends ConsumerState<SurahSelectionScreen> {
       }
       if (event.logicalKey == LogicalKeyboardKey.arrowRight) {
         setState(() {
-          selectedIndex = (selectedIndex + 1) % surahs.length;
+          if(textDirection == TextDirection.ltr) {
+            selectedIndex = (selectedIndex + 1) % surahs.length;
+          } else {
+            selectedIndex = (selectedIndex - 1 + surahs.length) % surahs.length;
+          }
         });
         _scrollToSelectedItem();
       } else if (event.logicalKey == LogicalKeyboardKey.arrowLeft) {
         setState(() {
-          selectedIndex = (selectedIndex - 1 + surahs.length) % surahs.length;
+          if(textDirection == TextDirection.ltr) {
+            selectedIndex = (selectedIndex - 1) % surahs.length;
+          } else {
+            selectedIndex = (selectedIndex + 1 + surahs.length) % surahs.length;
+          }
         });
         _scrollToSelectedItem();
       } else if (event.logicalKey == LogicalKeyboardKey.arrowUp) {

--- a/lib/src/pages/quran/page/surah_selection_screen.dart
+++ b/lib/src/pages/quran/page/surah_selection_screen.dart
@@ -146,7 +146,7 @@ class _SurahSelectionScreenState extends ConsumerState<SurahSelectionScreen> {
       }
       if (event.logicalKey == LogicalKeyboardKey.arrowRight) {
         setState(() {
-          if(textDirection == TextDirection.ltr) {
+          if (textDirection == TextDirection.ltr) {
             selectedIndex = (selectedIndex + 1) % surahs.length;
           } else {
             selectedIndex = (selectedIndex - 1 + surahs.length) % surahs.length;
@@ -155,7 +155,7 @@ class _SurahSelectionScreenState extends ConsumerState<SurahSelectionScreen> {
         _scrollToSelectedItem();
       } else if (event.logicalKey == LogicalKeyboardKey.arrowLeft) {
         setState(() {
-          if(textDirection == TextDirection.ltr) {
+          if (textDirection == TextDirection.ltr) {
             selectedIndex = (selectedIndex - 1) % surahs.length;
           } else {
             selectedIndex = (selectedIndex + 1 + surahs.length) % surahs.length;


### PR DESCRIPTION
📝 **Summary**
---

**Description**
---
This PR adds directionality support for surah navigation in the Quran app. It modifies the `_handleKeyEvent` method in the `SurahSelectionScreen` to consider the text direction (LTR or RTL) when handling left and right arrow key events. This enhancement improves the user experience for users in RTL languages.

**Tests**
---
🧪 **Use case 1**
---
💬 **Description:**
1. Open the Surah Selection Screen
2. Test navigation using arrow keys in both LTR and RTL configurations
3. Verify that the selection moves correctly based on the text direction:
   - In LTR: Right arrow moves forward, Left arrow moves backward
   - In RTL: Right arrow moves backward, Left arrow moves forward

📷 **Screenshots or GIFs (if applicable):**

![choose_surah](https://github.com/user-attachments/assets/45059ba5-e61f-4dee-b8a1-ccc650659d69)

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).