### PR TITLE
fix: keep previous player status on previous or next

### DIFF
--- a/lib/src/state_management/quran/recite/quran_audio_player_notifier.dart
+++ b/lib/src/state_management/quran/recite/quran_audio_player_notifier.dart
@@ -59,9 +59,7 @@ class QuranAudioPlayer extends AsyncNotifier<QuranAudioPlayerState> {
     currentIndexSubscription = audioPlayer.currentIndexStream.listen((index) {
       log('quran: QuranAudioPlayer: currentIndexStream called');
       final index = audioPlayer.currentIndex ?? 0;
-      final currentPlayerState = audioPlayer.playing
-          ? AudioPlayerState.playing
-          : AudioPlayerState.paused;
+      final currentPlayerState = audioPlayer.playing ? AudioPlayerState.playing : AudioPlayerState.paused;
       state = AsyncData(
         state.value!.copyWith(
           surahName: localSuwar[index].name,

--- a/lib/src/state_management/quran/recite/quran_audio_player_notifier.dart
+++ b/lib/src/state_management/quran/recite/quran_audio_player_notifier.dart
@@ -59,10 +59,13 @@ class QuranAudioPlayer extends AsyncNotifier<QuranAudioPlayerState> {
     currentIndexSubscription = audioPlayer.currentIndexStream.listen((index) {
       log('quran: QuranAudioPlayer: currentIndexStream called');
       final index = audioPlayer.currentIndex ?? 0;
+      final currentPlayerState = audioPlayer.playing
+          ? AudioPlayerState.playing
+          : AudioPlayerState.paused;
       state = AsyncData(
         state.value!.copyWith(
           surahName: localSuwar[index].name,
-          playerState: AudioPlayerState.playing,
+          playerState: currentPlayerState,
           reciterName: moshaf.name,
         ),
       );


### PR DESCRIPTION
📝 **Summary**
---
**Description**
---
This PR modifies the `QuranAudioPlayer` class to keep track of the previous player status when the current index changes. The change ensures that the player state accurately reflects whether the audio is playing or paused, even when transitioning between surahs.

Key changes:
- Retained the check for the current playing status of `audioPlayer`
- Set the `playerState` based on the actual playing status when the current index changes


**Tests**
---
🧪 **Use case 1: Transitioning between surahs while playing**
---
💬 **Description:**
1. Initialize the QuranAudioPlayer with multiple surahs
2. Start playing from the first surah
3. Allow the player to naturally transition to the next surah
4. Verify that the player state remains "playing" during and after the transition

https://github.com/user-attachments/assets/2eeed96e-96fe-49f3-a862-e74f46ea9afc

🧪 **Use case 2: Changing surah while paused**
---
💬 **Description:**
1. Initialize the QuranAudioPlayer with multiple surahs
2. Start playing, then pause on the first surah
3. Manually change to the next surah
4. Verify that the player state remains "paused" after the change
5. Check that the UI accurately reflects the paused state

📷 **Screenshots or GIFs (if applicable):**

https://github.com/user-attachments/assets/be1a853d-cb37-4ee1-b112-5100d6160242

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).