### PR TITLE
fix: localization for error text in the download_quran_popup 

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -262,5 +262,6 @@
       }
     }
   },
-  "chooseQuranPage": "Choose the page"
+  "chooseQuranPage": "Choose the page",
+  "checkingForUpdates": "Checking for updates..."
 }

--- a/lib/src/pages/quran/widget/download_quran_popup.dart
+++ b/lib/src/pages/quran/widget/download_quran_popup.dart
@@ -67,7 +67,7 @@ class DownloadQuranPopup extends AsyncNotifier<void> {
                 } else if (state is Success) {
                   return _buildSuccessPopup(context, state.version);
                 } else {
-                  return _buildInitialPopup(context, ref);
+                  return _buildInitialPopup(context);
                 }
               },
               loading: () => _buildCheckingPopup(context),
@@ -144,15 +144,16 @@ class DownloadQuranPopup extends AsyncNotifier<void> {
     );
   }
 
-  Widget _buildInitialPopup(BuildContext context, WidgetRef ref) {
+  Widget _buildInitialPopup(BuildContext context) {
+    final l10n = S.of(context);
     return AlertDialog(
-      title: const Text('Checking for Updates'),
+      title: Text(l10n.checkingForUpdates),
       content: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
           const CircularProgressIndicator(),
           const SizedBox(height: 8),
-          const Text('Checking for updates...'),
+          Text('${l10n.checkingForUpdates}...'),
         ],
       ),
       actions: [

--- a/lib/src/pages/quran/widget/download_quran_popup.dart
+++ b/lib/src/pages/quran/widget/download_quran_popup.dart
@@ -197,9 +197,10 @@ class DownloadQuranPopup extends AsyncNotifier<void> {
   }
 
   Widget _buildErrorPopup(BuildContext context, Object error) {
+    final l10n = S.of(context);
     return AlertDialog(
       title: Text(S.of(context).error),
-      content: Text('An error occurred: $error'),
+      content: Text(l10n.error),
       actions: [
         TextButton(
           onPressed: () => Navigator.pop(context),


### PR DESCRIPTION
📝 **Summary**
---
This PR adds localization for error text in the download_quran_popup and for the "checking for updates" message.

**Description**
---
This pull request introduces localization improvements for the Quran download popup and the update checking process. It adds new localized strings and updates the existing code to use these localized messages, enhancing the user experience for non-English speakers.

Key changes include:
1. Added a new localized string for "Checking for updates..." in `intl_en.arb`.
2. Updated `download_quran_popup.dart` to use localized strings for error messages and update checking status.
3. Removed an unused parameter in the `_buildInitialPopup` method.

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).