### PR TITLE
fix: prevent Multiple Dialogs in the Reading screen

### DIFF
--- a/lib/src/pages/quran/page/reciter_selection_screen.dart
+++ b/lib/src/pages/quran/page/reciter_selection_screen.dart
@@ -457,14 +457,6 @@ class _ReciterSelectionScreenState extends ConsumerState<ReciterSelectionScreen>
     if (value is RawKeyDownEvent) {
       if (value.logicalKey == LogicalKeyboardKey.arrowUp) {
         FocusScope.of(context).requestFocus(reciteTypeFocusNode);
-      } else if (value.logicalKey == LogicalKeyboardKey.select || value.logicalKey == LogicalKeyboardKey.enter) {
-        ref.read(quranNotifierProvider.notifier).selectModel(QuranMode.reading);
-        Navigator.pushReplacement(
-          context,
-          MaterialPageRoute(
-            builder: (context) => QuranReadingScreen(),
-          ),
-        );
       }
     }
   }


### PR DESCRIPTION
📝 **Summary**
---
**This PR for issue:** Resolving the issue of pushing multiple dialogs due to mistakenly pushing two screens in `ReciterSelectionScreen`.

**Description**
---
This PR addresses the issue where multiple dialogs were displayed because the code mistakenly pushed two screens instead of one. By removing the redundant `pushReplacement`, the navigation logic is corrected to ensure only one screen is pushed, preventing multiple dialogs from appearing.

**Changes:**
1. **Removed `pushReplacement`:**
   - Removed the `Navigator.pushReplacement` call to prevent multiple screens from being pushed and multiple dialogs from appearing. This ensures the navigation stack remains consistent and only the intended screen is displayed.

**Tests**
---
🧪 **Use case 1**
---
💬 **Description:**
- Verified that only one screen is pushed when selecting an item, ensuring no multiple dialogs appear.
- Ensured that the focus visually updates to indicate the currently selected item.
- Tested the navigation flow to ensure there are no disruptions or focus losses.

📷 **Screenshots or GIFs (if applicable):**

![multiple_push_reading_screen](https://github.com/user-attachments/assets/675cf3a2-a1ae-4889-991b-33dbe8495478)

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).