### PR TITLE
fix the range error in the reciter selector screen

### DIFF
--- a/lib/src/state_management/quran/recite/recite_state.dart
+++ b/lib/src/state_management/quran/recite/recite_state.dart
@@ -30,7 +30,8 @@ class ReciteState extends Equatable {
 
   @override
   String toString() {
-    return 'ReciteState(reciters: ${reciters[0]}) selectedReciter: ${selectedReciter.hashCode} selectedMoshaf: ${selectedMoshaf.hashCode})';
+    final reciterInfo = reciters.isNotEmpty ? reciters[0] : 'No reciters';
+    return 'ReciteState(reciters: $reciterInfo, selectedReciter: ${selectedReciter?.hashCode}, selectedMoshaf: ${selectedMoshaf?.hashCode})';
   }
 
   @override


### PR DESCRIPTION
📝 **Summary**
---

**Issue**: #1275 
**This PR for issue:** fixes ReciteState toString method

**Description**
---
This PR fixes the `toString` method of the `ReciteState` class to provide more informative output. The changes include:

1. Displaying information about the first reciter in the list, or a message if the list is empty.
2. Using the `hashCode` of `selectedReciter` and `selectedMoshaf` for a more concise representation.

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [ ] **Testing:** I have tested the changes and they work as expected.
- [ ] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).