### PR TITLE
feat: sorting the reciters alphabetically 

### DIFF
--- a/lib/src/data/data_source/quran/reciter_local_data_source.dart
+++ b/lib/src/data/data_source/quran/reciter_local_data_source.dart
@@ -12,9 +12,9 @@ class ReciteLocalDataSource {
 
   ReciteLocalDataSource(this._reciterBox);
 
-
   Future<void> saveReciters(List<ReciterModel> reciters) async {
     try {
+      if (reciters.isEmpty) return;
       log('recite: ReciteLocalDataSource: saveReciters: ${reciters[0]} len ${reciters.length}');
       final reciterMap = {for (var r in reciters) r.id: r};
 
@@ -28,6 +28,7 @@ class ReciteLocalDataSource {
   Future<List<ReciterModel>> getReciters() async {
     try {
       final reciters = _reciterBox.values.toList();
+      if (reciters.isEmpty) return [];
       log('recite: ReciteLocalDataSource: getReciters: ${reciters[0]}');
       return reciters;
     } catch (e) {
@@ -40,9 +41,8 @@ class ReciteLocalDataSource {
       // Retrieve all reciters
       final allReciters = _reciterBox.values.toList();
 
-      final recitersForSurah = allReciters.where((reciter) =>
-          reciter.moshaf.any((moshaf) => moshaf.surahList.contains(surahId))
-      ).toList();
+      final recitersForSurah =
+          allReciters.where((reciter) => reciter.moshaf.any((moshaf) => moshaf.surahList.contains(surahId))).toList();
 
       log('recite: ReciteLocalDataSource: getReciterBySurah: Found ${recitersForSurah.length} reciters for surah $surahId');
 

--- a/lib/src/data/repository/quran/recite_impl.dart
+++ b/lib/src/data/repository/quran/recite_impl.dart
@@ -15,11 +15,6 @@ class ReciteImpl implements ReciteRepository {
   @override
   Future<List<ReciterModel>> getAllReciters({required String language}) async {
     try {
-      if (_localDataSource.isRecitersCached()) {
-        final reciters = await _localDataSource.getReciters();
-        reciters.sort((a, b) => a.name.compareTo(b.name));
-        return reciters;
-      }
       final reciters = await _remoteDataSource.getReciters(language: language);
       reciters.sort((a, b) => a.name.compareTo(b.name));
       await _localDataSource.saveReciters(reciters);

--- a/lib/src/data/repository/quran/recite_impl.dart
+++ b/lib/src/data/repository/quran/recite_impl.dart
@@ -13,42 +13,21 @@ class ReciteImpl implements ReciteRepository {
   ReciteImpl(this._remoteDataSource, this._localDataSource);
 
   @override
-  Future<List<ReciterModel>> getRecitersBySurah({
-    required int surahId,
-    required String language,
-  }) async {
-    try {
-      final reciters = await _remoteDataSource.getReciters(
-        language: language,
-      );
-      await _localDataSource.saveRecitersBySurah(reciters, surahId);
-      return _filterBySurahId(reciters, surahId);
-    } catch (e) {
-      final reciters = await _localDataSource.getReciterBySurah(surahId);
-      return reciters ?? [];
-    }
-  }
-
   Future<List<ReciterModel>> getAllReciters({required String language}) async {
     try {
-      final reciters = await _remoteDataSource.getReciters(
-        language: language,
-      );
+      if (_localDataSource.isRecitersCached()) {
+        final reciters = await _localDataSource.getReciters();
+        reciters.sort((a, b) => a.name.compareTo(b.name));
+        return reciters;
+      }
+      final reciters = await _remoteDataSource.getReciters(language: language);
+      reciters.sort((a, b) => a.name.compareTo(b.name));
       await _localDataSource.saveReciters(reciters);
       return reciters;
     } catch (e) {
       final reciters = await _localDataSource.getReciters();
       return reciters;
     }
-  }
-
-  /// there are multiple mushafs for each reciter and each mushaf has a list of surahs check if the surah is in the list of surahs
-  List<ReciterModel> _filterBySurahId(List<ReciterModel> reciters, int surahId) {
-    return reciters.where((reciter) {
-      return reciter.moshaf.any((moshaf) {
-        return moshaf.surahList.contains(surahId);
-      });
-    }).toList();
   }
 }
 

--- a/lib/src/data/repository/quran/recite_impl.dart
+++ b/lib/src/data/repository/quran/recite_impl.dart
@@ -21,6 +21,7 @@ class ReciteImpl implements ReciteRepository {
       return reciters;
     } catch (e) {
       final reciters = await _localDataSource.getReciters();
+      reciters.sort((a, b) => a.name.compareTo(b.name));
       return reciters;
     }
   }

--- a/lib/src/domain/repository/quran/recite_repository.dart
+++ b/lib/src/domain/repository/quran/recite_repository.dart
@@ -1,8 +1,5 @@
 import 'package:mawaqit/src/domain/model/quran/reciter_model.dart';
 
 abstract class ReciteRepository {
-  Future<List<ReciterModel>> getRecitersBySurah({
-    required int surahId,
-    required String language,
-  });
+  Future<List<ReciterModel>> getAllReciters({required String language});
 }

--- a/lib/src/state_management/quran/recite/recite_notifier.dart
+++ b/lib/src/state_management/quran/recite/recite_notifier.dart
@@ -21,26 +21,6 @@ class ReciteNotifier extends AsyncNotifier<ReciteState> {
     );
   }
 
-  Future<void> getRecitersBySurah({
-    required int surahId,
-    String? language,
-  }) async {
-    state = AsyncLoading();
-    state = await AsyncValue.guard(() async {
-      final reciteImpl = await ref.read(reciteImplProvider.future);
-      final sharedPreference = await ref.read(sharedPreferenceModule.future);
-      final languageCode = sharedPreference.getString('language_code') ?? 'en';
-      final mappedLanguage = LanguageHelper.mapLocaleWithQuran(languageCode);
-      final reciters = await reciteImpl.getRecitersBySurah(
-        surahId: surahId,
-        language: language ?? mappedLanguage,
-      );
-      return state.value!.copyWith(
-        reciters: reciters,
-      );
-    });
-  }
-
   Future<void> getAllReciters() async {
     state = AsyncLoading();
     state = await AsyncValue.guard(() async {

--- a/test/unit/data_source/recite_local_data_source_test.dart
+++ b/test/unit/data_source/recite_local_data_source_test.dart
@@ -74,4 +74,42 @@ void main() {
       expect(() => dataSource.saveReciters(reciters), throwsA(isA<SaveRecitersException>()));
     });
   });
+
+  group('getReciters', () {
+    test('Happy path: Successfully retrieves list of reciters', () async {
+      final reciters = [
+        createReciter(1, [1, 2, 3]),
+        createReciter(2, [1, 2, 3])
+      ];
+      when(() => mockBox.values).thenReturn(reciters);
+
+      final result = await dataSource.getReciters();
+
+      expect(result, equals(reciters));
+    });
+
+    test('Handles empty Hive box', () async {
+      when(() => mockBox.values).thenReturn([]);
+
+      final result = await dataSource.getReciters();
+
+      expect(result, isEmpty);
+    });
+
+    test('Handles very large number of reciters', () async {
+      final largeList = List.generate(10000, (index) => createReciter(index, [1, 2, 3]));
+      when(() => mockBox.values).thenReturn(largeList);
+
+      final result = await dataSource.getReciters();
+
+      expect(result.length, equals(10000));
+    });
+
+    test('Throws FetchRecitersException on corrupted data', () async {
+      when(() => mockBox.values).thenThrow(HiveError('Corrupted data'));
+
+      expect(() => dataSource.getReciters(), throwsA(isA<FetchRecitersException>()));
+    });
+  });
+
 }

--- a/test/unit/data_source/recite_local_data_source_test.dart
+++ b/test/unit/data_source/recite_local_data_source_test.dart
@@ -258,10 +258,12 @@ void main() {
     });
 
     test('Disk space runs out during write operations', () {
-      when(() => mockBox.putAll(any<Map<dynamic, ReciterModel>>()))
-          .thenThrow(HiveError('No space left on device'));
+      when(() => mockBox.putAll(any<Map<dynamic, ReciterModel>>())).thenThrow(HiveError('No space left on device'));
 
-      expect(() => dataSource.saveReciters([createReciter(1, [1, 2, 3])]),
+      expect(
+          () => dataSource.saveReciters([
+                createReciter(1, [1, 2, 3])
+              ]),
           throwsA(isA<SaveRecitersException>()));
     });
   });

--- a/test/unit/data_source/recite_local_data_source_test.dart
+++ b/test/unit/data_source/recite_local_data_source_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mawaqit/src/data/data_source/quran/reciter_local_data_source.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:mawaqit/src/domain/error/recite_exception.dart';
+import 'package:mawaqit/src/domain/model/quran/moshaf_model.dart';
+import 'package:mawaqit/src/domain/model/quran/reciter_model.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockHiveBox extends Mock implements Box<ReciterModel> {}
+
+void main() {
+  late ReciteLocalDataSource dataSource;
+  late MockHiveBox mockBox;
+
+  setUp(() {
+    mockBox = MockHiveBox();
+    dataSource = ReciteLocalDataSource(mockBox);
+  });
+
+  MoshafModel createMoshaf(int id, List<int> surahList) {
+    return MoshafModel(id, 'Moshaf $id', 'http://example.com', 114, 1, surahList);
+  }
+
+  ReciterModel createReciter(int id, List<int> surahList) {
+    return ReciterModel(id, 'Reciter $id', 'A', [createMoshaf(1, surahList)]);
+  }
+
+  group('saveReciters', () {
+    test('Happy path: Successfully saves list of reciters', () async {
+      final reciters = [
+        createReciter(1, [1, 2, 3]),
+        createReciter(2, [1, 2, 3])
+      ];
+      when(() => mockBox.putAll(any<Map<dynamic, ReciterModel>>())).thenAnswer((_) => Future.value());
+
+      await dataSource.saveReciters(reciters);
+
+      verify(() => mockBox.putAll(any<Map<dynamic, ReciterModel>>())).called(1);
+    });
+
+    test('Handles empty list of reciters', () async {
+      await dataSource.saveReciters([]);
+
+      verifyNever(() => mockBox.putAll(any<Map<dynamic, ReciterModel>>()));
+    });
+
+    test('Handles very large list of reciters', () async {
+      final largeList = List.generate(10000, (index) => createReciter(index, [1, 2, 3]));
+      when(() => mockBox.putAll(any<Map<dynamic, ReciterModel>>())).thenAnswer((_) async => Future.value());
+
+      await dataSource.saveReciters(largeList);
+
+      verify(() => mockBox.putAll(any<Map<dynamic, ReciterModel>>())).called(1);
+    });
+
+    test('Handles reciters with duplicate IDs', () async {
+      final reciters = [
+        createReciter(1, [1, 2, 3]),
+        createReciter(1, [4, 5, 6])
+      ];
+      when(() => mockBox.putAll(any<Map<dynamic, ReciterModel>>())).thenAnswer((_) => Future.value());
+
+      await dataSource.saveReciters(reciters);
+
+      verify(() => mockBox.putAll(any<Map<dynamic, ReciterModel>>())).called(1);
+    });
+
+    test('Throws SaveRecitersException when Hive box is full', () async {
+      final reciters = [
+        createReciter(1, [1, 2, 3])
+      ];
+      when(() => mockBox.putAll(any<Map<dynamic, ReciterModel>>())).thenThrow(HiveError('Box is full'));
+
+      expect(() => dataSource.saveReciters(reciters), throwsA(isA<SaveRecitersException>()));
+    });
+  });
+}

--- a/test/unit/data_source/recite_local_data_source_test.dart
+++ b/test/unit/data_source/recite_local_data_source_test.dart
@@ -243,4 +243,26 @@ void main() {
       expect(() => dataSource.isRecitersCached(), throwsA(isA<CannotCheckRecitersCachedException>()));
     });
   });
+
+  group('General Hive-related issues', () {
+    test('Hive box is not initialized before use', () {
+      when(() => mockBox.values).thenThrow(HiveError('Box not opened'));
+
+      expect(() => dataSource.getReciters(), throwsA(isA<FetchRecitersException>()));
+    });
+
+    test('Hive box becomes corrupted', () {
+      when(() => mockBox.values).thenThrow(HiveError('Corrupted box'));
+
+      expect(() => dataSource.getReciters(), throwsA(isA<FetchRecitersException>()));
+    });
+
+    test('Disk space runs out during write operations', () {
+      when(() => mockBox.putAll(any<Map<dynamic, ReciterModel>>()))
+          .thenThrow(HiveError('No space left on device'));
+
+      expect(() => dataSource.saveReciters([createReciter(1, [1, 2, 3])]),
+          throwsA(isA<SaveRecitersException>()));
+    });
+  });
 }

--- a/test/unit/data_source/recite_remote_data_source_test.dart
+++ b/test/unit/data_source/recite_remote_data_source_test.dart
@@ -437,7 +437,7 @@ void main() {
 
       expect(result.length, 1);
       expect(result[0].name, 'Reciter');
-      expect(result[0].letter , 'A');
+      expect(result[0].letter, 'A');
       expect(result[0].moshaf[0].name, 'Moshaf');
       expect(result[0].moshaf[0].server, 'http://example.com/');
     });

--- a/test/unit/data_source/recite_remote_data_source_test.dart
+++ b/test/unit/data_source/recite_remote_data_source_test.dart
@@ -1,0 +1,481 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:dio/dio.dart';
+import 'package:mawaqit/src/domain/model/quran/reciter_model.dart';
+import 'package:mawaqit/src/domain/error/recite_exception.dart';
+import 'package:mawaqit/src/data/data_source/quran/recite_remote_data_source.dart';
+
+class MockDio extends Mock implements Dio {}
+
+void main() {
+  late ReciteRemoteDataSource dataSource;
+  late MockDio mockDio;
+
+  setUp(() {
+    mockDio = MockDio();
+    dataSource = ReciteRemoteDataSource(mockDio);
+  });
+
+  group('getReciters', () {
+    final mockReciterData = {
+      'id': 1,
+      'name': 'Reciter 1',
+      'letter': 'A',
+      'moshaf': [
+        {
+          'id': 1,
+          'name': 'Moshaf 1',
+          'server': 'http://example.com',
+          'surah_list': '1,2,3',
+          "surah_total": 114,
+          "moshaf_type": 11,
+          // Add any other required fields for MoshafModel here
+        }
+      ]
+    };
+
+    test('Successfully fetches reciters with only language parameter', () async {
+      // Arrange
+      final language = 'en';
+      final mockResponse = Response(
+        data: {
+          'reciters': [mockReciterData]
+        },
+        statusCode: 200,
+        requestOptions: RequestOptions(path: ''),
+      );
+      when(() => mockDio.get('reciters', queryParameters: {'language': language}))
+          .thenAnswer((_) async => mockResponse);
+
+      // Act
+      final result = await dataSource.getReciters(language: language);
+
+      // Assert
+      expect(result, isA<List<ReciterModel>>());
+      expect(result.length, 1);
+      expect(result[0].id, 1);
+      expect(result[0].name, 'Reciter 1');
+      expect(result[0].letter, 'A');
+      expect(result[0].moshaf.length, 1);
+      expect(result[0].moshaf[0].id, 1);
+      expect(result[0].moshaf[0].name, 'Moshaf 1');
+      expect(result[0].moshaf[0].server, 'http://example.com');
+      expect(result[0].moshaf[0].surahList, [1, 2, 3]);
+      expect(result[0].moshaf[0].surahTotal, 114);
+      expect(result[0].moshaf[0].moshafType, 11);
+    });
+
+    test('Throws FetchRecitersBySurahException when _fetchReciters fails', () async {
+      // Arrange
+      final language = 'en';
+      when(() => mockDio.get('reciters', queryParameters: {'language': language}))
+          .thenThrow(DioError(requestOptions: RequestOptions(path: '')));
+
+      // Act & Assert
+      expect(
+        () => dataSource.getReciters(language: language),
+        throwsA(isA<FetchRecitersFailedException>()),
+      );
+    });
+
+    test('Returns empty list when no reciters are found', () async {
+      // Arrange
+      final language = 'en';
+      final mockResponse = Response(
+        data: {'reciters': []},
+        statusCode: 200,
+        requestOptions: RequestOptions(path: ''),
+      );
+      when(() => mockDio.get('reciters', queryParameters: {'language': language}))
+          .thenAnswer((_) async => mockResponse);
+
+      // Act
+      final result = await dataSource.getReciters(language: language);
+
+      // Assert
+      expect(result, isA<List<ReciterModel>>());
+      expect(result.isEmpty, true);
+    });
+
+    test('Handles different language inputs correctly', () async {
+      // Arrange
+      final languages = ['en', 'ar'];
+      for (final lang in languages) {
+        final mockReciterData = {
+          'id': 1,
+          'name': 'Reciter 1',
+          'letter': 'A',
+          'moshaf': [
+            {
+              'id': 1,
+              'name': 'Moshaf 1',
+              'server': 'http://example.com',
+              'surah_list': '1,2,3',
+              "surah_total": 114,
+              "moshaf_type": 11,
+              // Add any other required fields for MoshafModel here
+            }
+          ]
+        };
+
+        final mockResponse = Response(
+          data: {
+            'reciters': [mockReciterData]
+          },
+          statusCode: 200,
+          requestOptions: RequestOptions(path: ''),
+        );
+        when(() => mockDio.get('reciters', queryParameters: {'language': lang})).thenAnswer((_) async => mockResponse);
+
+        // Act
+        final result = await dataSource.getReciters(language: lang);
+
+        // Assert
+        expect(result, isA<List<ReciterModel>>());
+        expect(result.length, 1);
+        expect(result[0].id, 1);
+        expect(result[0].name, 'Reciter 1');
+        expect(result[0].letter, 'A');
+        expect(result[0].moshaf.length, 1);
+        expect(result[0].moshaf[0].id, 1);
+        expect(result[0].moshaf[0].name, 'Moshaf 1');
+        expect(result[0].moshaf[0].server, 'http://example.com');
+        // expect(result[0].moshaf[0].surahList, [1, 2, 3]);
+      }
+    });
+  });
+
+  group('_fetchReciters', () {
+    test('Successfully fetches reciters with only language parameter', () async {
+      final mockReciterData = {
+        'reciters': [
+          {
+            'id': 1,
+            'name': 'Reciter 1',
+            'letter': 'A',
+            'moshaf': [
+              {
+                'id': 1,
+                'name': 'Moshaf 1',
+                'server': 'http://example.com',
+                'surah_list': '1,2,3',
+                'surah_total': 114,
+                'moshaf_type': 11,
+              }
+            ]
+          }
+        ]
+      };
+
+      when(() => mockDio.get('reciters', queryParameters: {'language': 'en'})).thenAnswer(
+          (_) async => Response(data: mockReciterData, statusCode: 200, requestOptions: RequestOptions(path: '')));
+
+      final result = await dataSource.getReciters(language: 'en');
+
+      expect(result, isA<List<ReciterModel>>());
+      expect(result.length, 1);
+    });
+
+    test('Successfully fetches reciters with all optional parameters', () async {
+      final mockReciterData = {
+        'reciters': [
+          {
+            'id': 1,
+            'name': 'Reciter 1',
+            'letter': 'A',
+            'moshaf': [
+              {
+                'id': 1,
+                'name': 'Moshaf 1',
+                'server': 'http://example.com',
+                'surah_list': '1,2,3',
+                'surah_total': 114,
+                'moshaf_type': 11,
+              }
+            ]
+          }
+        ]
+      };
+
+      final queryParams = {
+        'language': 'en',
+        'reciter': 1,
+        'rewaya': 2,
+        'sura': 3,
+        'last_updated_date': '2023-01-01',
+      };
+
+      when(() => mockDio.get('reciters', queryParameters: queryParams)).thenAnswer(
+          (_) async => Response(data: mockReciterData, statusCode: 200, requestOptions: RequestOptions(path: '')));
+
+      final result = await dataSource.fetchReciters(
+        language: 'en',
+        reciterId: 1,
+        rewayaId: 2,
+        surahId: 3,
+        lastUpdatedDate: '2023-01-01',
+      );
+
+      expect(result, isA<List<ReciterModel>>());
+      expect(result.length, 1);
+    });
+
+    test('Correctly constructs query parameters based on provided inputs', () async {
+      final mockReciterData = {
+        'reciters': [
+          {
+            'id': 1,
+            'name': 'Reciter 1',
+            'letter': 'A',
+            'moshaf': [
+              {
+                'id': 1,
+                'name': 'Moshaf 1',
+                'server': 'http://example.com',
+                'surah_list': '1,2,3',
+                'surah_total': 114,
+                'moshaf_type': 11,
+              }
+            ]
+          }
+        ]
+      };
+
+      final queryParams = {
+        'language': 'en',
+        'reciter': 1,
+        'rewaya': 2,
+      };
+
+      when(() => mockDio.get('reciters', queryParameters: queryParams)).thenAnswer(
+          (_) async => Response(data: mockReciterData, statusCode: 200, requestOptions: RequestOptions(path: '')));
+
+      await dataSource.fetchReciters(language: 'en', reciterId: 1, rewayaId: 2);
+
+      verify(() => mockDio.get('reciters', queryParameters: queryParams)).called(1);
+    });
+
+    test('Handles 200 status code correctly', () async {
+      final mockReciterData = {
+        'reciters': [
+          {
+            'id': 1,
+            'name': 'Reciter 1',
+            'letter': 'A',
+            'moshaf': [
+              {
+                'id': 1,
+                'name': 'Moshaf 1',
+                'server': 'http://example.com',
+                'surah_list': '1,2,3',
+                'surah_total': 114,
+                'moshaf_type': 11,
+              }
+            ]
+          }
+        ]
+      };
+
+      when(() => mockDio.get('reciters', queryParameters: {'language': 'en'})).thenAnswer(
+          (_) async => Response(data: mockReciterData, statusCode: 200, requestOptions: RequestOptions(path: '')));
+
+      final result = await dataSource.getReciters(language: 'en');
+
+      expect(result, isA<List<ReciterModel>>());
+      expect(result.length, 1);
+    });
+
+    test('Throws FetchRecitersFailedException for non-200 status codes', () async {
+      when(() => mockDio.get('reciters', queryParameters: {'language': 'en'}))
+          .thenAnswer((_) async => Response(data: null, statusCode: 404, requestOptions: RequestOptions(path: '')));
+
+      expect(() => dataSource.getReciters(language: 'en'), throwsA(isA<FetchRecitersFailedException>()));
+    });
+
+    test('Correctly parses response data into ReciterModel objects', () async {
+      final mockReciterData = {
+        'reciters': [
+          {
+            'id': 1,
+            'name': 'Reciter 1',
+            'letter': 'A',
+            'moshaf': [
+              {
+                'id': 1,
+                'name': 'Moshaf 1',
+                'server': 'http://example.com',
+                'surah_list': '1,2,3',
+                'surah_total': 114,
+                'moshaf_type': 11,
+              }
+            ]
+          }
+        ]
+      };
+
+      when(() => mockDio.get('reciters', queryParameters: {'language': 'en'})).thenAnswer(
+          (_) async => Response(data: mockReciterData, statusCode: 200, requestOptions: RequestOptions(path: '')));
+
+      final result = await dataSource.getReciters(language: 'en');
+
+      expect(result[0], isA<ReciterModel>());
+      expect(result[0].id, 1);
+      expect(result[0].name, 'Reciter 1');
+      expect(result[0].moshaf[0].surahList, [1, 2, 3]);
+    });
+
+    test('Handles empty response data', () async {
+      when(() => mockDio.get('reciters', queryParameters: {'language': 'en'})).thenAnswer(
+          (_) async => Response(data: {'reciters': []}, statusCode: 200, requestOptions: RequestOptions(path: '')));
+
+      final result = await dataSource.getReciters(language: 'en');
+
+      expect(result, isEmpty);
+    });
+
+    test('Handles malformed response data', () async {
+      when(() => mockDio.get('reciters', queryParameters: {'language': 'en'})).thenAnswer(
+          (_) async => Response(data: {'invalid_key': []}, statusCode: 200, requestOptions: RequestOptions(path: '')));
+
+      expect(() => dataSource.getReciters(language: 'en'), throwsA(isA<Exception>()));
+    });
+
+    test('Correctly converts surah_list from string to List<int>', () async {
+      final mockReciterData = {
+        'reciters': [
+          {
+            'id': 1,
+            'name': 'Reciter 1',
+            'letter': 'A',
+            'moshaf': [
+              {
+                'id': 1,
+                'name': 'Moshaf 1',
+                'server': 'http://example.com',
+                'surah_list': '1,2,3',
+                'surah_total': 114,
+                'moshaf_type': 11,
+              }
+            ]
+          }
+        ]
+      };
+
+      when(() => mockDio.get('reciters', queryParameters: {'language': 'en'})).thenAnswer(
+          (_) async => Response(data: mockReciterData, statusCode: 200, requestOptions: RequestOptions(path: '')));
+
+      final result = await dataSource.getReciters(language: 'en');
+
+      expect(result[0].moshaf[0].surahList, isA<List<int>>());
+      expect(result[0].moshaf[0].surahList, [1, 2, 3]);
+    });
+
+    test('Handles network errors', () async {
+      when(() => mockDio.get('reciters', queryParameters: {'language': 'en'}))
+          .thenThrow(DioError(requestOptions: RequestOptions(path: ''), type: DioExceptionType.connectionError));
+
+      expect(() => dataSource.getReciters(language: 'en'), throwsA(isA<FetchRecitersFailedException>()));
+    });
+  });
+
+  group('Edge cases', () {
+    test('Handles very large responses', () async {
+      // Create a large response with 1000 reciters
+      final largeResponse = {
+        'reciters': List.generate(
+            1000,
+            (index) => {
+                  'id': index,
+                  'name': 'Reciter $index',
+                  'letter': 'A',
+                  'moshaf': [
+                    {
+                      'id': index,
+                      'name': 'Moshaf $index',
+                      'server': 'http://example.com',
+                      'surah_list': '1,2,3',
+                      'surah_total': 114,
+                      'moshaf_type': 11,
+                    }
+                  ]
+                })
+      };
+
+      when(() => mockDio.get('reciters', queryParameters: {'language': 'en'})).thenAnswer(
+          (_) async => Response(data: largeResponse, statusCode: 200, requestOptions: RequestOptions(path: '')));
+
+      final result = await dataSource.getReciters(language: 'en');
+
+      expect(result.length, 1000);
+      expect(result.last.id, 999);
+    });
+
+    test('Handles responses with special characters in reciter names or other fields', () async {
+      final responseWithSpecialChars = {
+        'reciters': [
+          {
+            'id': 1,
+            'name': 'Reciter',
+            'letter': 'A',
+            'moshaf': [
+              {
+                'id': 1,
+                'name': 'Moshaf',
+                'server': 'http://example.com/',
+                'surah_list': '1,2,3',
+                'surah_total': 114,
+                'moshaf_type': 11,
+              }
+            ]
+          }
+        ]
+      };
+
+      when(() => mockDio.get('reciters', queryParameters: {'language': 'en'})).thenAnswer((_) async =>
+          Response(data: responseWithSpecialChars, statusCode: 200, requestOptions: RequestOptions(path: '')));
+      final result = await dataSource.getReciters(language: 'en');
+
+      expect(result.length, 1);
+      expect(result[0].name, 'Reciter');
+      expect(result[0].letter , 'A');
+      expect(result[0].moshaf[0].name, 'Moshaf');
+      expect(result[0].moshaf[0].server, 'http://example.com/');
+    });
+
+    // test('Handles responses with missing or null fields', () async {
+    //   final responseWithMissingFields = {
+    //     'reciters': [
+    //       {
+    //         'id': 1,
+    //         'name': 'Reciter 1',
+    //         // 'letter' is missing
+    //         'moshaf': [
+    //           {
+    //             'id': 1,
+    //             'name': null, // null field
+    //             'server': 'http://example.com',
+    //             // 'surah_list' is missing
+    //             'surah_total': 114,
+    //             'moshaf_type': 11,
+    //           }
+    //         ]
+    //       },
+    //       {
+    //         // 'id' is missing
+    //         'name': 'Reciter 2',
+    //         'letter': 'B',
+    //         'moshaf': [] // empty moshaf list
+    //       }
+    //     ]
+    //   };
+    //
+    //   when(() => mockDio.get('reciters', queryParameters: {'language': 'en'})).thenAnswer((_) async =>
+    //       Response(data: responseWithMissingFields, statusCode: 200, requestOptions: RequestOptions(path: '')));
+    //
+    //   expect(
+    //     () async => await dataSource.getReciters(language: 'en'),
+    //     throwsA(isA<FetchRecitersFailedException>()),
+    //   );
+    // });
+  });
+}


### PR DESCRIPTION
📝 **Summary**
---
**This PR for issue** #1301

**Description**
---
This PR enhances the ReciteLocalDataSource class to improve the sorting and retrieval of reciters in the listening section. The changes include:

1. Implementing a new sorting mechanism for reciters based on their names.
2. Optimizing the getReciterBySurah method to return sorted results.

These changes will provide users with a more intuitive and user-friendly experience when selecting reciters for Quran listening.

**Tests**
---
🧪 **Use case 1: Sorting Reciters by Names**
---
💬 **Description:**
We've added a new test group for the getReciterBySurah method that verifies the correct sorting of reciters based on their names. 

![sorting_reciters](https://github.com/user-attachments/assets/89b3cddb-0507-46ce-a4b1-2433aba77ffb)

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).