### PR TITLE
chore: noReciterSearchResult message

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -335,7 +335,7 @@
   "@noFavoriteReciters": {
     "description": "Message shown when there are no favorite reciters"
   },
-    "noReciterSearchResult": "No results found for your search. Try a new reciter",
+    "noReciterSearchResult": "No results found for your search",
     "searchForReciter": "Search for a reciter",
   "downloadAllSuwarSuccessfully": "The whole quran is downloaded",
   "noSuwarDownload": "No new suwars to download",


### PR DESCRIPTION
This PR updates the text in the localization file (lib/l10n/intl_en.arb) to improve the clarity of the message shown when no reciter search results are found. Specifically, the message has been simplified from:

Old message: "No results found for your search. Try a new reciter"

to

New message: "No results found for your search"