### PR TITLE
Fix/ Use cached suwar values if already fetched

### DIFF
--- a/lib/src/data/repository/quran/quran_impl.dart
+++ b/lib/src/data/repository/quran/quran_impl.dart
@@ -28,13 +28,16 @@ class QuranImpl extends QuranRepository {
     String languageCode = 'en',
   }) async {
     try {
+      if (await _quranLocalDataSource.isSuwarByLanguageFound(languageCode)) {
+        return _quranLocalDataSource.getSuwarByLanguage(languageCode);
+      }
+
       final suwar = await _quranRemoteDataSource.getSuwarByLanguage(languageCode: languageCode);
       log('quran: QuranImpl: getSuwarByLanguage: ${suwar[0]}');
       await _quranLocalDataSource.saveSuwarByLanguage(languageCode, suwar);
       return suwar;
-    } on Exception catch (_) {
-      final suwar = await _quranLocalDataSource.getSuwarByLanguage(languageCode);
-      return suwar;
+    } catch (_) {
+      return _quranLocalDataSource.getSuwarByLanguage(languageCode);
     }
   }
 }


### PR DESCRIPTION
📝 **Summary**
---
This PR fixes always fetching suwar names by using the already cached values. 

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).