### PR TITLE
fix: issue with filtering favorite reciters not updating after changes.

### DIFF
--- a/lib/src/state_management/quran/recite/recite_state.dart
+++ b/lib/src/state_management/quran/recite/recite_state.dart
@@ -47,8 +47,9 @@ class ReciteState extends Equatable {
     final reciterInfo = reciters.isNotEmpty ? reciters[0] : 'No reciters';
     return 'ReciteState(reciters: $reciterInfo, selectedReciter: ${selectedReciter.hashCode}, '
         'selectedMoshaf: ${selectedMoshaf.hashCode},'
-        'filteredReciters: ${filteredReciters.length}'
-        'filteredFavoriteReciters: ${filteredFavoriteReciters.length})';
+        'filteredReciters: ${filteredReciters.length},'
+        'filteredFavoriteReciters: ${filteredFavoriteReciters.length},'
+        'favoriteReciters: ${favoriteReciters.length})';
   }
 
   @override


### PR DESCRIPTION
📝 **Summary**
---

This PR fixes an issue where the filteredFavoriteReciters list was not updated after changes, ensuring synchronization between the filtered reciter and favorite reciter lists after adding or removing a favorite.

**This PR for issue**  

**Description**
---

- Introduced _currentQuery and _isAllReciters to track the current search state.
- Updated the logic in setSearchQuery to debounce and recalculate the filtered lists.
- Synchronized both the filteredReciters and filteredFavoriteReciters when modifying the favorite reciters list.
- Ensured that both regular and favorite reciters are updated when the favorite list changes or when a new search query is set.

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).
