### PR TITLE
fix: update reciter box constant to resolve favorite reciter fetch issue

### DIFF
--- a/lib/src/const/constants.dart
+++ b/lib/src/const/constants.dart
@@ -72,7 +72,7 @@ abstract class QuranConstant {
   static const String kSelectedMoshafType = 'selected_moshaf_type';
   static const String kQuranBaseUrl = 'https://mp3quran.net/api/v3/';
   static const String kSurahBox = 'surah_box';
-  static const String kReciterBox = 'reciter_box';
+  static const String kReciterBox = 'reciter_box_v2';
   static const String kQuranModePref = 'quran_mode';
   static const String kSavedCurrentPage = 'saved_current_page';
   static const String kFavoriteReciterBox = 'favorite_reciter_box';


### PR DESCRIPTION
📝 **Summary**
---
**This PR for issue**  
FetchFavoriteRecitersException: Instance of 'FetchFavoriteRecitersException' (Issue #1373)

**Description**
---
This PR resolves an issue where fetching favorite reciters was causing an exception due to an outdated `kReciterBox` constant. The constant was updated to `kReciterBox_v2` in order to address the problem.

**Tests**
---
🧪 **Use case 1**
---
💬 **Description:**
Fetch favorite reciters now works without any exceptions.

📷 **Screenshots or GIFs (if applicable):**
N/A

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).