### PR TITLE
refactor: Salah Timing Logic and UI Highlight Condition

### DIFF
--- a/lib/src/pages/home/widgets/salah_items/horizontal_salah_item.dart
+++ b/lib/src/pages/home/widgets/salah_items/horizontal_salah_item.dart
@@ -44,14 +44,18 @@ class HorizontalSalahItem extends StatelessWidget {
 
     final mosqueProvider = context.watch<MosqueManager>();
     final mosqueConfig = mosqueProvider.mosqueConfig;
+    final iqamaEnabled = mosqueConfig?.iqamaEnabled == true;
 
     final is24period = mosqueConfig?.timeDisplayFormat != "12";
+
+    // Determine if the item should be highlighted
+    final shouldHighlight = active && (!iqamaEnabled || (iqama?.isNotEmpty ?? false));
 
     return Container(
       margin: margin ?? EdgeInsets.symmetric(horizontal: 5.vw),
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(3.vw),
-        color: active
+        color: shouldHighlight
             ? mosqueProvider.getColorTheme().withOpacity(.5)
             : removeBackground
                 ? null


### PR DESCRIPTION
📝 **Summary**  
---  
**This PR fixes** #1352  

**Description**  
---  
This PR addresses the issue where the next Salah is incorrectly highlighted immediately after the prayer time has started, even if the Iqama time for that Salah is yet to come. The updated logic ensures that the highlight appears only after the Iqama time has passed. This change is made in the `mosque_helpers_mixins.dart` file, where the `nextSalahIndex()` function has been modified to prioritize Iqama times (if enabled) before falling back to actual prayer times. Additionally, a small update in `horizontal_salah_item.dart` ensures that only the current or next Salah is highlighted as intended.  

**Tests**  
---  

🧪 **Use Case 1**  
---  
💬 **Description:**  
Launch the app and verify that the next Salah is only highlighted once the Iqama time has passed. Set a current time just after a prayer start time but before the Iqama time, and ensure the highlight does not activate prematurely.  

📷 **Screenshots or GIFs (if applicable):**  

![image](https://github.com/user-attachments/assets/e1d38fdc-1224-4b63-a94c-cfe0b3383bc4)

![image](https://github.com/user-attachments/assets/76a7af7a-1d96-46a3-ada9-a64d09fb1c79)

![image](https://github.com/user-attachments/assets/d3f60042-eebb-461e-a335-f7ec3390eaa3)  

**Checklist:**  
---  
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.  
- [x] **Testing:** I have tested the changes, and they work as expected.  
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.  
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).  