### PR TITLE
Feat/close quran when salah

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,11 +1,12 @@
 import 'package:fast_cached_network_image/fast_cached_network_image.dart';
+import 'dart:async';
+import 'dart:developer' as developer;
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_kurdish_localization/flutter_kurdish_localization.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart'
-    show ProviderBase, ProviderContainer, ProviderObserver, ProviderScope;
+import 'package:flutter_riverpod/flutter_riverpod.dart' as riverpod;
 import 'package:hive_flutter/adapters.dart';
 import 'package:logger/logger.dart';
 import 'package:mawaqit/i18n/AppLanguage.dart';
@@ -33,6 +34,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:provider/provider.dart';
 import 'package:sizer/sizer.dart';
 import 'package:timezone/data/latest.dart' as tz;
+import 'package:mawaqit/src/routes/route_generator.dart';
 
 final logger = Logger();
 
@@ -50,7 +52,7 @@ Future<void> main() async {
       Hive.registerAdapter(ReciterModelAdapter());
       Hive.registerAdapter(MoshafModelAdapter());
       runApp(
-        ProviderScope(
+        riverpod.ProviderScope(
           child: MyApp(),
           observers: [
             RiverpodLogger(),
@@ -62,9 +64,9 @@ Future<void> main() async {
   );
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends riverpod.ConsumerWidget {
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, riverpod.WidgetRef ref) {
     return MultiProvider(
       providers: [
         ChangeNotifierProvider(create: (context) => ThemeNotifier()),
@@ -88,35 +90,40 @@ class MyApp extends StatelessWidget {
               return event;
             }),
             child: Consumer<ThemeNotifier>(
-              builder: (context, theme, _) => Shortcuts(
-                shortcuts: {SingleActivator(LogicalKeyboardKey.select): ActivateIntent()},
-                child: MaterialApp(
-                  title: kAppName,
-                  themeMode: theme.mode,
-                  localeResolutionCallback: (locale, supportedLocales) {
-                    if (locale?.languageCode.toLowerCase() == 'ba') return Locale('en');
+              builder: (context, theme, _) {
+                return Shortcuts(
+                  shortcuts: {SingleActivator(LogicalKeyboardKey.select): ActivateIntent()},
+                  child: MaterialApp(
+                    title: kAppName,
+                    themeMode: theme.mode,
+                    localeResolutionCallback: (locale, supportedLocales) {
+                      if (locale?.languageCode.toLowerCase() == 'ba') return Locale('en');
 
-                    return locale;
-                  },
-                  theme: theme.lightTheme,
-                  darkTheme: theme.darkTheme,
-                  locale: model.appLocal,
-                  navigatorKey: AppRouter.navigationKey,
-                  navigatorObservers: [AnalyticsWrapper.observer()],
-                  localizationsDelegates: [
-                    S.delegate,
-                    GlobalCupertinoLocalizations.delegate,
-                    GlobalMaterialLocalizations.delegate,
-                    GlobalWidgetsLocalizations.delegate,
-                    KurdishMaterialLocalizations.delegate,
-                    KurdishWidgetLocalizations.delegate,
-                    KurdishCupertinoLocalizations.delegate
-                  ],
-                  supportedLocales: S.supportedLocales,
-                  debugShowCheckedModeBanner: false,
-                  home: Splash(),
-                ),
-              ),
+                      return locale;
+                    },
+                    theme: theme.lightTheme,
+                    darkTheme: theme.darkTheme,
+                    locale: model.appLocal,
+                    navigatorKey: AppRouter.navigationKey,
+                    navigatorObservers: [
+                      AnalyticsWrapper.observer(),
+                    ],
+                    localizationsDelegates: [
+                      S.delegate,
+                      GlobalCupertinoLocalizations.delegate,
+                      GlobalMaterialLocalizations.delegate,
+                      GlobalWidgetsLocalizations.delegate,
+                      KurdishMaterialLocalizations.delegate,
+                      KurdishWidgetLocalizations.delegate,
+                      KurdishCupertinoLocalizations.delegate
+                    ],
+                    supportedLocales: S.supportedLocales,
+                    debugShowCheckedModeBanner: false,
+                    onGenerateRoute: RouteGenerator.generateRoute,
+                    home: Splash(),
+                  ),
+                );
+              },
             ),
           );
         });

--- a/lib/src/pages/home/sub_screens/AdhanSubScreen.dart
+++ b/lib/src/pages/home/sub_screens/AdhanSubScreen.dart
@@ -2,6 +2,7 @@ import 'dart:developer';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mawaqit/i18n/l10n.dart';
 import 'package:mawaqit/main.dart';
 import 'package:mawaqit/src/helpers/RelativeSizes.dart';
@@ -12,13 +13,14 @@ import 'package:mawaqit/src/pages/home/widgets/mosque_background_screen.dart';
 import 'package:mawaqit/src/pages/home/widgets/salah_items/responsive_mini_salah_bar_widget.dart';
 import 'package:mawaqit/src/services/audio_manager.dart';
 import 'package:mawaqit/src/services/mosque_manager.dart';
+import 'package:mawaqit/src/state_management/quran/quran/quran_notifier.dart';
 import 'package:mawaqit/src/themes/UIShadows.dart';
 import 'package:provider/provider.dart';
 
 import '../widgets/mosque_header.dart';
 import '../widgets/salah_items/responsive_mini_salah_bar_turkish_widget.dart';
 
-class AdhanSubScreen extends StatefulWidget {
+class AdhanSubScreen extends ConsumerStatefulWidget {
   const AdhanSubScreen({Key? key, this.onDone, this.forceAdhan = false}) : super(key: key);
 
   final VoidCallback? onDone;
@@ -27,10 +29,10 @@ class AdhanSubScreen extends StatefulWidget {
   final bool forceAdhan;
 
   @override
-  State<AdhanSubScreen> createState() => _AdhanSubScreenState();
+  ConsumerState<AdhanSubScreen> createState() => _AdhanSubScreenState();
 }
 
-class _AdhanSubScreenState extends State<AdhanSubScreen> {
+class _AdhanSubScreenState extends ConsumerState<AdhanSubScreen> {
   AudioManager? audioManager;
 
   /// if mosque using Beb sound we will wait for minutes delay
@@ -45,6 +47,10 @@ class _AdhanSubScreenState extends State<AdhanSubScreen> {
     audioManager = context.read<AudioManager>();
     final isFajrPray = mosqueManager.salahIndex == 0;
     final duration = mosqueManager.getAdhanDuration(isFajrPray);
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      ref.read(quranNotifierProvider.notifier).exitQuranMode();
+    });
 
     Future.delayed(Duration(minutes: 5), () {
       closeAdhanScreen();

--- a/lib/src/pages/home/sub_screens/AdhanSubScreen.dart
+++ b/lib/src/pages/home/sub_screens/AdhanSubScreen.dart
@@ -14,6 +14,7 @@ import 'package:mawaqit/src/pages/home/widgets/salah_items/responsive_mini_salah
 import 'package:mawaqit/src/services/audio_manager.dart';
 import 'package:mawaqit/src/services/mosque_manager.dart';
 import 'package:mawaqit/src/state_management/quran/quran/quran_notifier.dart';
+import 'package:mawaqit/src/state_management/quran/recite/quran_audio_player_notifier.dart';
 import 'package:mawaqit/src/themes/UIShadows.dart';
 import 'package:provider/provider.dart';
 
@@ -49,6 +50,7 @@ class _AdhanSubScreenState extends ConsumerState<AdhanSubScreen> {
     final duration = mosqueManager.getAdhanDuration(isFajrPray);
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      ref.read(quranPlayerNotifierProvider.notifier).pause();
       ref.read(quranNotifierProvider.notifier).exitQuranMode();
     });
 

--- a/lib/src/pages/home/sub_screens/JummuaLive.dart
+++ b/lib/src/pages/home/sub_screens/JummuaLive.dart
@@ -6,6 +6,7 @@ import 'package:mawaqit/i18n/l10n.dart';
 import 'package:mawaqit/src/helpers/RelativeSizes.dart';
 import 'package:mawaqit/src/models/address_model.dart';
 import 'package:mawaqit/src/services/mosque_manager.dart';
+import 'package:mawaqit/src/state_management/quran/quran/quran_notifier.dart';
 import 'package:mawaqit/src/themes/UIShadows.dart';
 import 'package:provider/provider.dart';
 
@@ -34,6 +35,11 @@ class _JummuaLiveState extends ConsumerState<JummuaLive> {
   @override
   void initState() {
     invalidStreamUrl = context.read<MosqueManager>().mosque?.streamUrl == null;
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      ref.read(quranNotifierProvider.notifier).exitQuranMode();
+    });
+
     log('JummuaLive: invalidStreamUrl: $invalidStreamUrl');
     super.initState();
   }

--- a/lib/src/pages/home/workflow/salah_workflow.dart
+++ b/lib/src/pages/home/workflow/salah_workflow.dart
@@ -33,7 +33,8 @@ class SalahWorkflowScreen extends ConsumerStatefulWidget {
   ConsumerState<SalahWorkflowScreen> createState() => _SalahWorkflowScreenState();
 }
 
-class _SalahWorkflowScreenState extends ConsumerState<SalahWorkflowScreen> { // Changed to ConsumerState
+class _SalahWorkflowScreenState extends ConsumerState<SalahWorkflowScreen> {
+  // Changed to ConsumerState
   @override
   void initState() {
     super.initState();

--- a/lib/src/pages/home/workflow/salah_workflow.dart
+++ b/lib/src/pages/home/workflow/salah_workflow.dart
@@ -12,13 +12,15 @@ import 'package:mawaqit/src/pages/home/sub_screens/normal_home.dart';
 import 'package:mawaqit/src/pages/home/widgets/workflows/repeating_workflow_widget.dart';
 import 'package:mawaqit/src/services/mosque_manager.dart';
 import 'package:mawaqit/src/services/user_preferences_manager.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mawaqit/src/state_management/quran/quran/quran_notifier.dart';
 import 'package:provider/provider.dart';
 
 import '../sub_screens/AdhanSubScreen.dart';
 import '../widgets/workflows/WorkFlowWidget.dart';
 
 /// handling the logic form 5min before adhan -> the last of after salah azkar
-class SalahWorkflowScreen extends StatefulWidget {
+class SalahWorkflowScreen extends ConsumerStatefulWidget {
   const SalahWorkflowScreen({
     Key? key,
     required this.onDone,
@@ -28,10 +30,18 @@ class SalahWorkflowScreen extends StatefulWidget {
   final void Function() onDone;
 
   @override
-  State<SalahWorkflowScreen> createState() => _SalahWorkflowScreenState();
+  ConsumerState<SalahWorkflowScreen> createState() => _SalahWorkflowScreenState();
 }
 
-class _SalahWorkflowScreenState extends State<SalahWorkflowScreen> {
+class _SalahWorkflowScreenState extends ConsumerState<SalahWorkflowScreen> { // Changed to ConsumerState
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      ref.read(quranNotifierProvider.notifier).exitQuranMode();
+    });
+  }
+
   calculateCurrentSalah(MosqueManager mosqueManger) {
     if (mosqueManger.nextSalahAfter() < Duration(minutes: 5)) return mosqueManger.nextSalahIndex();
 

--- a/lib/src/pages/home/workflow/salah_workflow.dart
+++ b/lib/src/pages/home/workflow/salah_workflow.dart
@@ -13,7 +13,6 @@ import 'package:mawaqit/src/pages/home/widgets/workflows/repeating_workflow_widg
 import 'package:mawaqit/src/services/mosque_manager.dart';
 import 'package:mawaqit/src/services/user_preferences_manager.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:mawaqit/src/state_management/quran/quran/quran_notifier.dart';
 import 'package:provider/provider.dart';
 
 import '../sub_screens/AdhanSubScreen.dart';
@@ -38,9 +37,6 @@ class _SalahWorkflowScreenState extends ConsumerState<SalahWorkflowScreen> {
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      ref.read(quranNotifierProvider.notifier).exitQuranMode();
-    });
   }
 
   calculateCurrentSalah(MosqueManager mosqueManger) {

--- a/lib/src/pages/quran/page/quran_mode_selection_screen.dart
+++ b/lib/src/pages/quran/page/quran_mode_selection_screen.dart
@@ -8,6 +8,7 @@ import 'package:mawaqit/src/pages/quran/widget/quran_background.dart';
 import 'package:mawaqit/src/state_management/quran/quran/quran_state.dart';
 import 'package:sizer/sizer.dart';
 import 'package:mawaqit/src/state_management/quran/quran/quran_notifier.dart';
+import 'package:mawaqit/src/routes/routes_constant.dart';
 
 class QuranModeSelection extends ConsumerStatefulWidget {
   const QuranModeSelection({super.key});
@@ -66,22 +67,22 @@ class _QuranModeSelectionState extends ConsumerState<QuranModeSelection> {
       } else if (event.logicalKey == LogicalKeyboardKey.select) {
         if (_selectedIndex == 0) {
           ref.read(quranNotifierProvider.notifier).selectModel(QuranMode.reading);
-          Navigator.pushReplacement(
-            context,
-            MaterialPageRoute(
-              builder: (context) => QuranReadingScreen(),
-            ),
-          );
+          Navigator.pushReplacementNamed(context, Routes.quranReading);
         } else {
           ref.read(quranNotifierProvider.notifier).selectModel(QuranMode.listening);
-          Navigator.pushReplacement(
-            context,
-            MaterialPageRoute(
-              builder: (context) => ReciterSelectionScreen.withoutSurahName(),
-            ),
-          );
+          Navigator.pushReplacementNamed(context, Routes.quranReciter);
         }
       }
+    }
+  }
+
+  void _handleNavigation(int index) {
+    if (index == 0) {
+      ref.read(quranNotifierProvider.notifier).selectModel(QuranMode.reading);
+      Navigator.pushReplacementNamed(context, Routes.quranReading);
+    } else {
+      ref.read(quranNotifierProvider.notifier).selectModel(QuranMode.listening);
+      Navigator.pushReplacementNamed(context, Routes.quranReciter);
     }
   }
 
@@ -122,13 +123,7 @@ class _QuranModeSelectionState extends ConsumerState<QuranModeSelection> {
                       setState(() {
                         _selectedIndex = 0;
                       });
-                      ref.read(quranNotifierProvider.notifier).selectModel(QuranMode.reading);
-                      Navigator.pushReplacement(
-                        context,
-                        MaterialPageRoute(
-                          builder: (context) => QuranReadingScreen(),
-                        ),
-                      );
+                      _handleNavigation(0);
                     },
                     isSelected: _selectedIndex == 0,
                     focusNode: _readingFocusNode,
@@ -141,13 +136,7 @@ class _QuranModeSelectionState extends ConsumerState<QuranModeSelection> {
                       setState(() {
                         _selectedIndex = 1;
                       });
-                      ref.read(quranNotifierProvider.notifier).selectModel(QuranMode.listening);
-                      Navigator.pushReplacement(
-                        context,
-                        MaterialPageRoute(
-                          builder: (context) => ReciterSelectionScreen.withoutSurahName(),
-                        ),
-                      );
+                      _handleNavigation(1);
                     },
                     isSelected: _selectedIndex == 1,
                     focusNode: _listeningFocusNode,
@@ -172,7 +161,7 @@ class _QuranModeSelectionState extends ConsumerState<QuranModeSelection> {
     return Focus(
       focusNode: focusNode,
       child: GestureDetector(
-        onTap: onPressed,
+        onTap: () => _handleNavigation(isSelected ? 0 : 1),
         child: AnimatedContainer(
           duration: Duration(milliseconds: 200),
           width: 50.w,

--- a/lib/src/pages/quran/page/quran_mode_selection_screen.dart
+++ b/lib/src/pages/quran/page/quran_mode_selection_screen.dart
@@ -42,7 +42,7 @@ class _QuranModeSelectionState extends ConsumerState<QuranModeSelection> {
     super.dispose();
   }
 
-  void _handleKeyEvent(RawKeyEvent event) {
+  Future<void> _handleKeyEvent(RawKeyEvent event) async {
     if (event is RawKeyDownEvent) {
       final isLtr = Directionality.of(context) == TextDirection.ltr;
 
@@ -66,11 +66,15 @@ class _QuranModeSelectionState extends ConsumerState<QuranModeSelection> {
         }
       } else if (event.logicalKey == LogicalKeyboardKey.select) {
         if (_selectedIndex == 0) {
-          ref.read(quranNotifierProvider.notifier).selectModel(QuranMode.reading);
-          Navigator.pushReplacementNamed(context, Routes.quranReading);
+          await ref.read(quranNotifierProvider.notifier).selectModel(QuranMode.reading);
+          if(mounted){
+            Navigator.pushReplacementNamed(context, Routes.quranReading);
+          }
         } else {
-          ref.read(quranNotifierProvider.notifier).selectModel(QuranMode.listening);
-          Navigator.pushReplacementNamed(context, Routes.quranReciter);
+          await ref.read(quranNotifierProvider.notifier).selectModel(QuranMode.listening);
+          if(mounted) {
+            Navigator.pushReplacementNamed(context, Routes.quranReciter);
+          }
         }
       }
     }

--- a/lib/src/pages/quran/page/quran_mode_selection_screen.dart
+++ b/lib/src/pages/quran/page/quran_mode_selection_screen.dart
@@ -67,12 +67,12 @@ class _QuranModeSelectionState extends ConsumerState<QuranModeSelection> {
       } else if (event.logicalKey == LogicalKeyboardKey.select) {
         if (_selectedIndex == 0) {
           await ref.read(quranNotifierProvider.notifier).selectModel(QuranMode.reading);
-          if(mounted){
+          if (mounted) {
             Navigator.pushReplacementNamed(context, Routes.quranReading);
           }
         } else {
           await ref.read(quranNotifierProvider.notifier).selectModel(QuranMode.listening);
-          if(mounted) {
+          if (mounted) {
             Navigator.pushReplacementNamed(context, Routes.quranReciter);
           }
         }

--- a/lib/src/pages/quran/page/reciter_selection_screen.dart
+++ b/lib/src/pages/quran/page/reciter_selection_screen.dart
@@ -24,6 +24,7 @@ import 'package:mawaqit/src/pages/quran/widget/reciter_list_view.dart';
 
 import '../../../domain/model/quran/reciter_model.dart';
 import '../reading/quran_reading_screen.dart';
+import 'package:mawaqit/src/routes/routes_constant.dart';
 
 class ReciterSelectionScreen extends ConsumerStatefulWidget {
   final String surahName;
@@ -109,6 +110,11 @@ class _ReciterSelectionScreenState extends ConsumerState<ReciterSelectionScreen>
     ref.read(reciteNotifierProvider.notifier).setSearchQuery(_searchController.text, isAllReciters);
   }
 
+  void _navigateToReading() {
+    ref.read(quranNotifierProvider.notifier).selectModel(QuranMode.reading);
+    Navigator.pushReplacementNamed(context, Routes.quranReading);
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -125,15 +131,7 @@ class _ReciterSelectionScreenState extends ConsumerState<ReciterSelectionScreen>
             color: Colors.white,
             size: 15.sp,
           ),
-          onPressed: () async {
-            ref.read(quranNotifierProvider.notifier).selectModel(QuranMode.reading);
-            Navigator.pushReplacement(
-              context,
-              MaterialPageRoute(
-                builder: (context) => QuranReadingScreen(),
-              ),
-            );
-          },
+          onPressed: _navigateToReading,
         ),
       ),
       appBar: AppBar(

--- a/lib/src/pages/quran/page/surah_selection_screen.dart
+++ b/lib/src/pages/quran/page/surah_selection_screen.dart
@@ -23,6 +23,7 @@ import '../../../models/address_model.dart';
 import '../../../services/theme_manager.dart';
 import '../../../state_management/quran/recite/download_audio_quran/download_audio_quran_notifier.dart';
 import '../../../state_management/quran/recite/download_audio_quran/download_audio_quran_state.dart';
+import 'package:mawaqit/src/routes/routes_constant.dart';
 
 class SurahSelectionScreen extends ConsumerStatefulWidget {
   final MoshafModel selectedMoshaf;
@@ -91,18 +92,17 @@ class _SurahSelectionScreenState extends ConsumerState<SurahSelectionScreen> {
           suwar: suwar,
           reciterId: widget.reciterId,
         );
-    Navigator.push(
+
+    Navigator.pushNamed(
       context,
-      MaterialPageRoute(
-        builder: (context) => QuranPlayerScreen(
-          reciterId: widget.reciterId,
-          selectedMoshaf: widget.selectedMoshaf,
-          surah: surah,
-        ),
-      ),
-    ).then((_) {
-      _isNavigating = false;
-    });
+      Routes.quranPlayer,
+      arguments: {
+        'reciterId': widget.reciterId,
+        'selectedMoshaf': widget.selectedMoshaf,
+        'surah': surah,
+      },
+    );
+    _isNavigating = false;
   }
 
   String _getKey() {

--- a/lib/src/pages/quran/reading/quran_reading_screen.dart
+++ b/lib/src/pages/quran/reading/quran_reading_screen.dart
@@ -13,6 +13,8 @@ import 'package:mawaqit/src/pages/quran/widget/reading/quran_surah_selector.dart
 import 'package:mawaqit/src/services/user_preferences_manager.dart';
 import 'package:mawaqit/src/state_management/quran/download_quran/download_quran_notifier.dart';
 import 'package:mawaqit/src/state_management/quran/download_quran/download_quran_state.dart';
+import 'package:mawaqit/src/state_management/quran/quran/quran_notifier.dart';
+import 'package:mawaqit/src/state_management/quran/quran/quran_state.dart';
 import 'package:mawaqit/src/state_management/quran/reading/auto_reading/auto_reading_notifier.dart';
 import 'package:mawaqit/src/state_management/quran/reading/auto_reading/auto_reading_state.dart';
 import 'package:mawaqit/src/state_management/quran/reading/quran_reading_notifer.dart';
@@ -22,6 +24,7 @@ import 'package:mawaqit/src/state_management/quran/reading/quran_reading_state.d
 import 'package:provider/provider.dart' as provider;
 
 import 'package:mawaqit/src/pages/quran/widget/reading/quran_reading_page_selector.dart';
+import 'package:mawaqit/src/routes/routes_constant.dart';
 
 abstract class QuranViewStrategy {
   Widget buildView(QuranReadingState state, WidgetRef ref, BuildContext context);
@@ -279,6 +282,11 @@ class _QuranReadingScreenState extends ConsumerState<QuranReadingScreen> {
     _portraitModePageSelectorFocusNode.dispose();
     _switchToPlayQuranFocusNode.dispose();
     _surahSelectorNode.dispose();
+  }
+
+  void _navigateToListeningMode() {
+    ref.read(quranNotifierProvider.notifier).selectModel(QuranMode.listening);
+    Navigator.pushReplacementNamed(context, Routes.quranReciter);
   }
 
   @override

--- a/lib/src/pages/quran/reading/widget/quran_floating_action_buttons.dart
+++ b/lib/src/pages/quran/reading/widget/quran_floating_action_buttons.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mawaqit/src/pages/quran/page/reciter_selection_screen.dart';
+import 'package:mawaqit/src/routes/routes_constant.dart';
 import 'package:mawaqit/src/state_management/quran/quran/quran_notifier.dart';
 import 'package:mawaqit/src/state_management/quran/quran/quran_state.dart';
 import 'package:mawaqit/src/state_management/quran/reading/auto_reading/auto_reading_notifier.dart';
@@ -98,14 +99,9 @@ class _QuranModeButton extends ConsumerWidget {
           color: Colors.white,
           size: iconSize,
         ),
-        onPressed: () async {
+        onPressed: () {
           ref.read(quranNotifierProvider.notifier).selectModel(QuranMode.listening);
-          Navigator.pushReplacement(
-            context,
-            MaterialPageRoute(
-              builder: (context) => ReciterSelectionScreen.withoutSurahName(),
-            ),
-          );
+          Navigator.pushReplacementNamed(context, Routes.quranReciter);
         },
         heroTag: null,
       ),

--- a/lib/src/pages/quran/widget/quran_background.dart
+++ b/lib/src/pages/quran/widget/quran_background.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mawaqit/const/resource.dart';
 import 'package:mawaqit/src/pages/quran/reading/quran_reading_screen.dart';
+import 'package:mawaqit/src/routes/routes_constant.dart';
 import 'package:mawaqit/src/services/theme_manager.dart';
 import 'package:sizer/sizer.dart';
 
@@ -47,11 +48,9 @@ class QuranBackground extends ConsumerWidget {
                         onPressed: () async {
                           ref.read(quranNotifierProvider.notifier).selectModel(QuranMode.reading);
                           log('quran: QuranBackground: Switch to reading');
-                          Navigator.pushReplacement(
+                          Navigator.pushReplacementNamed(
                             context,
-                            MaterialPageRoute(
-                              builder: (context) => QuranReadingScreen(),
-                            ),
+                            Routes.quranReading,
                           );
                         },
                       ),
@@ -90,11 +89,9 @@ class QuranBackground extends ConsumerWidget {
                         ),
                         onPressed: () async {
                           ref.read(quranNotifierProvider.notifier).selectModel(QuranMode.reading);
-                          Navigator.pushReplacement(
+                          Navigator.pushReplacementNamed(
                             context,
-                            MaterialPageRoute(
-                              builder: (context) => QuranReadingScreen(),
-                            ),
+                            Routes.quranReading,
                           );
                         },
                       ),

--- a/lib/src/routes/route_generator.dart
+++ b/lib/src/routes/route_generator.dart
@@ -30,10 +30,17 @@ class RouteGenerator {
               final quranState = ref.watch(quranNotifierProvider);
               if (quranState.value?.mode == QuranMode.none) {
                 WidgetsBinding.instance.addPostFrameCallback((_) {
-                  if (Navigator.canPop(context)) {
-                    Navigator.pop(context);
+                  // Get the navigator state
+                  final navigator = Navigator.of(context);
+                  // Pop until we reach the root or can't pop anymore
+                  while (navigator.canPop()) {
+                    // Pop both dialog and screen if in listening mode
+                    if (Routes.quranScreens.contains(settings.name)) {
+                      navigator.pop();
+                    }
                   }
                 });
+                return const SizedBox(); // Return empty widget while popping
               }
               return _buildQuranScreen(settings, context);
             },

--- a/lib/src/routes/route_generator.dart
+++ b/lib/src/routes/route_generator.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mawaqit/src/domain/model/quran/moshaf_model.dart';
+import 'package:mawaqit/src/domain/model/quran/surah_model.dart';
+import 'package:mawaqit/src/pages/quran/page/quran_mode_selection_screen.dart';
+import 'package:mawaqit/src/pages/quran/page/quran_player_screen.dart';
+import 'package:mawaqit/src/pages/quran/page/reciter_selection_screen.dart';
+import 'package:mawaqit/src/pages/quran/page/surah_selection_screen.dart';
+import 'package:mawaqit/src/pages/quran/reading/quran_reading_screen.dart';
+import 'package:mawaqit/src/routes/routes_constant.dart';
+import 'package:mawaqit/src/pages/SplashScreen.dart';
+import 'package:mawaqit/src/state_management/quran/quran/quran_notifier.dart';
+import 'package:mawaqit/src/state_management/quran/quran/quran_state.dart';
+
+class RouteGenerator {
+  static Route<dynamic> generateRoute(RouteSettings settings) {
+    // Check if the route is a Quran screen
+    if (Routes.quranScreens.contains(settings.name)) {
+      return MaterialPageRoute(
+        builder: (context) {
+          return Consumer(
+            builder: (context, ref, child) {
+              final quranState = ref.watch(quranNotifierProvider);
+              if (quranState.value?.mode == QuranMode.none) {
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  if (Navigator.canPop(context)) {
+                    Navigator.pop(context);
+                  }
+                });
+              }
+              return _buildQuranScreen(settings, context);
+            },
+          );
+        },
+      );
+    }
+
+    // Handle non-Quran routes
+    switch (settings.name) {
+      case '/':
+        return MaterialPageRoute(builder: (_) => Splash());
+      default:
+        return _errorRoute();
+    }
+  }
+
+  static Widget _buildQuranScreen(RouteSettings settings, BuildContext context) {
+    switch (settings.name) {
+      case Routes.quranModeSelection:
+        return const QuranModeSelection();
+
+      case Routes.quranReading:
+        return const QuranReadingScreen();
+
+      case Routes.quranReciter:
+        return const ReciterSelectionScreen.withoutSurahName();
+
+      case Routes.quranSurah:
+        final args = settings.arguments as Map<String, dynamic>;
+        return SurahSelectionScreen(
+          selectedMoshaf: args['selectedMoshaf'] as MoshafModel,
+          reciterId: args['reciterId'] as String,
+        );
+
+      case Routes.quranPlayer:
+        final args = settings.arguments as Map<String, dynamic>;
+        return QuranPlayerScreen(
+          reciterId: args['reciterId'] as String,
+          selectedMoshaf: args['selectedMoshaf'] as MoshafModel,
+          surah: args['surah'] as SurahModel,
+        );
+
+      default:
+        return const SizedBox();
+    }
+  }
+
+  static Route<dynamic> _errorRoute() {
+    return MaterialPageRoute(
+      builder: (_) => Scaffold(
+        appBar: AppBar(title: const Text('Error')),
+        body: const Center(child: Text('Route not found')),
+      ),
+    );
+  }
+}

--- a/lib/src/routes/route_generator.dart
+++ b/lib/src/routes/route_generator.dart
@@ -14,6 +14,13 @@ import 'package:mawaqit/src/state_management/quran/quran/quran_state.dart';
 
 class RouteGenerator {
   static Route<dynamic> generateRoute(RouteSettings settings) {
+    // Special handling for QuranModeSelection
+    if (settings.name == Routes.quranModeSelection) {
+      return MaterialPageRoute(
+        builder: (context) => const QuranModeSelection(),
+      );
+    }
+
     // Check if the route is a Quran screen
     if (Routes.quranScreens.contains(settings.name)) {
       return MaterialPageRoute(

--- a/lib/src/routes/routes_constant.dart
+++ b/lib/src/routes/routes_constant.dart
@@ -1,0 +1,15 @@
+class Routes {
+  static const String quranModeSelection = '/quran';
+  static const String quranReading = '/quran/reading';
+  static const String quranReciter = '/quran/reciter';
+  static const String quranSurah = '/quran/surah';
+  static const String quranPlayer = '/quran/player';
+
+  static const List<String> quranScreens = [
+    quranModeSelection,
+    quranReading,
+    quranReciter,
+    quranSurah,
+    quranPlayer,
+  ];
+}

--- a/lib/src/state_management/quran/quran/quran_notifier.dart
+++ b/lib/src/state_management/quran/quran/quran_notifier.dart
@@ -85,7 +85,7 @@ class QuranNotifier extends AsyncNotifier<QuranState> {
   }
 
   void exitQuranMode() {
-    try{
+    try {
       state = AsyncData(state.value!.copyWith(mode: QuranMode.none));
     } catch (err, stack) {
       state = AsyncError(err, stack);

--- a/lib/src/state_management/quran/quran/quran_notifier.dart
+++ b/lib/src/state_management/quran/quran/quran_notifier.dart
@@ -83,6 +83,14 @@ class QuranNotifier extends AsyncNotifier<QuranState> {
       }
     });
   }
+
+  void exitQuranMode() {
+    try{
+      state = AsyncData(state.value!.copyWith(mode: QuranMode.none));
+    } catch (err, stack) {
+      state = AsyncError(err, stack);
+    }
+  }
 }
 
 final quranNotifierProvider = AsyncNotifierProvider<QuranNotifier, QuranState>(QuranNotifier.new);

--- a/lib/src/widgets/MawaqitDrawer.dart
+++ b/lib/src/widgets/MawaqitDrawer.dart
@@ -20,6 +20,7 @@ import 'package:mawaqit/src/pages/AboutScreen.dart';
 import 'package:mawaqit/src/pages/PageScreen.dart';
 import 'package:mawaqit/src/pages/WebScreen.dart';
 import 'package:mawaqit/src/pages/quran/page/reciter_selection_screen.dart';
+import 'package:mawaqit/src/routes/routes_constant.dart';
 import 'package:mawaqit/src/services/mosque_manager.dart';
 import 'package:mawaqit/src/services/settings_manager.dart';
 import 'package:mawaqit/src/services/user_preferences_manager.dart';
@@ -174,20 +175,19 @@ class MawaqitDrawer extends ConsumerWidget {
                 onTap: () async {
                   await ref.read(quranNotifierProvider.notifier).getSelectedMode();
                   final state = ref.read(quranNotifierProvider);
+                  Navigator.pop(context);
+
                   switch (state.value!.mode) {
                     case QuranMode.reading:
                       log('quran: MawaqitDrawer: build: quranNotifierProvider: mode: reading');
-                      Navigator.pop(context);
-                      AppRouter.push(QuranReadingScreen());
+                      Navigator.pushNamed(context, Routes.quranReading);
                       break;
                     case QuranMode.listening:
                       log('quran: MawaqitDrawer: build: quranNotifierProvider: mode: listening');
-                      Navigator.pop(context);
-                      AppRouter.push(ReciterSelectionScreen.withoutSurahName());
+                      Navigator.pushNamed(context, Routes.quranReciter);
                       break;
                     case QuranMode.none:
-                      Navigator.pop(context);
-                      AppRouter.push(QuranModeSelection());
+                      Navigator.pushNamed(context, Routes.quranModeSelection);
                       break;
                   }
                 },


### PR DESCRIPTION
📝 **Summary**
---
**This PR fixes**

**Description**
---
This PR refactors the navigation logic in the Quran module to use named routes instead of direct widget instantiation, enhancing code maintainability and readability. It also introduces an automatic exit from Quran mode when Salah (prayer time) is detected, ensuring the user flow is seamless without unnecessary interruptions during Salah.

### Key Changes:
- Replaced `MaterialPageRoute` navigation with `Navigator.pushReplacementNamed` for Quran-related routes.
- Added an `exitQuranMode` function in `QuranNotifier` to switch `QuranMode` to `none` when Salah starts.
- Modified `SalahWorkflowScreen` to call `exitQuranMode` upon initialization to handle the mode transition smoothly.
- Consolidated all route paths in `Routes` class for centralized management.
- Integrated `RouteGenerator` in `main.dart` for streamlined route handling.

**Tests**
---
🧪 **Use case 1**
---
💬 **Description:**
Launch the app, start a Quran session, and ensure the Quran mode automatically closes when Salah begins, returning to the main screen or showing relevant prayer notifications.

![get_out_from_quran](https://github.com/user-attachments/assets/2ba1326f-f68a-4842-b572-0d6a7776d49c)

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).
