### PR TITLE
refactor: remove the successful download for quran dialog

### DIFF
--- a/lib/src/pages/quran/widget/download_quran_popup.dart
+++ b/lib/src/pages/quran/widget/download_quran_popup.dart
@@ -50,7 +50,7 @@ class _DownloadQuranDialogState extends ConsumerState<DownloadQuranDialog> {
       // UpdateAvailable() => _buildUpdateAvailableDialog(context, state),
       Downloading() => _buildDownloadingDialog(context, state),
       Extracting() => _buildExtractingDialog(context, state),
-      Success() => _buildSuccessDialog(context, state),
+      Success() => _successDialog(context),
       CancelDownload() => Container(),
       // NoUpdate() => _buildNoUpdateDialog(context, state),
       _ => Container(),
@@ -123,19 +123,6 @@ class _DownloadQuranDialogState extends ConsumerState<DownloadQuranDialog> {
           Text('${state.progress.toStringAsFixed(2)}%'),
         ],
       ),
-    );
-  }
-
-  Widget _buildSuccessDialog(BuildContext context, Success state) {
-    return AlertDialog(
-      title: Text(S.of(context).quranDownloaded),
-      actions: [
-        TextButton(
-          autofocus: true,
-          onPressed: () => Navigator.pop(context),
-          child: Text(S.of(context).ok),
-        ),
-      ],
     );
   }
 
@@ -231,5 +218,15 @@ class _DownloadQuranDialogState extends ConsumerState<DownloadQuranDialog> {
         ),
       ],
     );
+  }
+
+  Widget _successDialog(BuildContext context) {
+    Future.microtask(() {
+      // Close the current dialog
+      if (Navigator.canPop(context)) {
+        Navigator.pop(context);
+      }
+    });
+    return Container();
   }
 }


### PR DESCRIPTION
Here’s your updated PR description based on the patch and the details you provided:

📝 Summary

This PR fixes #1446 

This PR refactors the DownloadQuranDialog widget to remove the business need for displaying a dialog upon successful Quran download. The success state is now handled silently by closing the current dialog without showing a success message or dialog to the user. This change simplifies the user experience and reduces potential performance overhead, especially on devices with limited hardware capabilities.


Tests

🧪 Use Case 1
💬 Description:
Launch the app and trigger a Quran download. Verify the following:
	•	Once the download is successful, the dialog is dismissed automatically.
	•	No success dialog or additional UI elements are displayed.
	•	The state transitions smoothly without affecting the user experience.

📷 Screenshots or GIFs (if applicable):
(Not applicable for this PR, as no new UI elements are introduced.)
