### PR TITLE
fix: Resolve pop-up issue when selecting Listening mode

### DIFF
--- a/lib/src/pages/quran/page/quran_mode_selection_screen.dart
+++ b/lib/src/pages/quran/page/quran_mode_selection_screen.dart
@@ -80,12 +80,12 @@ class _QuranModeSelectionState extends ConsumerState<QuranModeSelection> {
     }
   }
 
-  void _handleNavigation(int index) {
+  Future<void> _handleNavigation(int index) async {
     if (index == 0) {
-      ref.read(quranNotifierProvider.notifier).selectModel(QuranMode.reading);
+      await ref.read(quranNotifierProvider.notifier).selectModel(QuranMode.reading);
       Navigator.pushReplacementNamed(context, Routes.quranReading);
     } else {
-      ref.read(quranNotifierProvider.notifier).selectModel(QuranMode.listening);
+      await ref.read(quranNotifierProvider.notifier).selectModel(QuranMode.listening);
       Navigator.pushReplacementNamed(context, Routes.quranReciter);
     }
   }

--- a/lib/src/pages/quran/widget/download_quran_popup.dart
+++ b/lib/src/pages/quran/widget/download_quran_popup.dart
@@ -125,7 +125,6 @@ class _DownloadQuranDialogState extends ConsumerState<DownloadQuranDialog> {
             onPressed: () async {
               final notifier = ref.read(downloadQuranNotifierProvider.notifier);
               final moshafType = ref.watch(moshafTypeNotifierProvider);
-
               ref.read(moshafTypeNotifierProvider).maybeWhen(
                     orElse: () {},
                     data: (state) async {
@@ -211,7 +210,18 @@ class _DownloadQuranDialogState extends ConsumerState<DownloadQuranDialog> {
         actions: [
           TextButton(
             onPressed: () {
-              Navigator.pop(context);
+              final moshafType = ref.watch(moshafTypeNotifierProvider);
+              moshafType.when(
+                data: (data) {
+                  if (data.isFirstTime) {
+                    Navigator.popUntil(context, (route) => route.isFirst);
+                  } else {
+                    Navigator.pop(context);
+                  }
+                },
+                error: (_, __) {},
+                loading: () {},
+              );
             },
             child: Text(S.of(context).cancel),
           ),


### PR DESCRIPTION
###  📝 Summary

This PR fixes #1453 

### Description

This PR introduces a hotfix to improve the Quran mode selection and download flow. The following changes were made:
•	Quran Mode Selection Screen:
•	Ensured that the selection of Quran modes (reading or listening) is now asynchronous.
•	Added await to ensure the mode selection completes before navigating to the appropriate screen (QuranReading or QuranReciter).
•	Download Quran Popup:
•	Improved the navigation flow by ensuring proper handling of the moshafType.
•	Adjusted the cancel button behavior to account for the isFirstTime state:
•	If isFirstTime is true, the dialog will close all the way back to the first screen.
•	If isFirstTime is false, it will close the current dialog only.

These changes aim to enhance the user experience and ensure a smoother transition across screens.

### Tests

🧪 Use case 1

💬 Description:
	1.	Navigate to the Quran mode selection screen.
	2.	Select either the Reading or Listening mode.
	3.	Verify that the app waits for mode selection to complete before transitioning to the appropriate screen.

📷 Screenshots or GIFs (if applicable):

![listening](https://github.com/user-attachments/assets/cc2e9d8b-dffc-437f-bc8c-4a49ff97bad3)

