### PR TITLE
fix: Resolve overlapping and focus issues for Back and Switch buttons

### DIFF
--- a/lib/src/pages/quran/reading/quran_reading_screen.dart
+++ b/lib/src/pages/quran/reading/quran_reading_screen.dart
@@ -136,11 +136,6 @@ class NormalViewStrategy implements QuranViewStrategy {
   ) {
     if (isPortrait) {
       return [
-        BackButtonWidget(
-          isPortrait: isPortrait,
-          userPrefs: userPrefs,
-          focusNode: focusNodes.backButtonNode,
-        ),
         SurahSelectorWidget(
           isPortrait: isPortrait,
           focusNode: focusNodes.surahSelectorNode,
@@ -157,15 +152,15 @@ class NormalViewStrategy implements QuranViewStrategy {
           focusNode: focusNodes.switchQuranNode,
           isThereCurrentDialogShowing: false,
         ),
+        BackButtonWidget(
+          isPortrait: isPortrait,
+          userPrefs: userPrefs,
+          focusNode: focusNodes.backButtonNode,
+        ),
       ];
     }
 
     return [
-      BackButtonWidget(
-        isPortrait: isPortrait,
-        userPrefs: userPrefs,
-        focusNode: focusNodes.backButtonNode,
-      ),
       _buildNavigationButtons(
         context,
         focusNodes,
@@ -187,6 +182,11 @@ class NormalViewStrategy implements QuranViewStrategy {
         isPortrait: isPortrait,
         focusNode: focusNodes.switchQuranNode,
         isThereCurrentDialogShowing: false,
+      ),
+      BackButtonWidget(
+        isPortrait: isPortrait,
+        userPrefs: userPrefs,
+        focusNode: focusNodes.backButtonNode,
       ),
     ];
   }


### PR DESCRIPTION
# 📝 Summary
---
**This PR fixes** #1456 

---

## **Description**
This PR resolves the overlapping and focus issues between the **Back** and **Switch** buttons in the Quran reading screen.

### **Key Changes**
- Fixed overlapping of the **Back** and **Switch** buttons in portrait mode by adjusting the layout and ensuring proper vertical spacing.
- Improved focus traversal logic, enabling smooth navigation between the **Back** and **Switch** buttons.

These improvements enhance both the visual appearance and the user interaction experience.

---

## **Tests**

### 🧪 Use case 1
**💬 Description:**
1. Open the Quran reading screen in **portrait mode**.
2. Verify that the **Back** and **Switch** buttons no longer overlap.
3. Test the focus navigation between the buttons to ensure smooth transitions.

**📷 Screenshots or GIFs (if applicable):**

![portrait_mode_back](https://github.com/user-attachments/assets/3e07caa6-5879-44f7-a195-29d88a44ae71)

---

### 🧪 Use case 2
**💬 Description:**
1. Rotate the device to **landscape mode**.
2. Confirm that the layout changes do not negatively affect button placement or behavior in this mode.

![horizontal](https://github.com/user-attachments/assets/7de12b39-b59b-455c-909b-be3149f52a37)

---

## **Checklist**
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).