### PR TITLE
fix: Move Surah Selector to Avoid Overlapping Text

### DIFF
--- a/lib/src/pages/quran/reading/quran_reading_screen.dart
+++ b/lib/src/pages/quran/reading/quran_reading_screen.dart
@@ -25,6 +25,7 @@ import 'package:provider/provider.dart' as provider;
 
 import 'package:mawaqit/src/pages/quran/widget/reading/quran_reading_page_selector.dart';
 import 'package:mawaqit/src/routes/routes_constant.dart';
+import 'package:sizer/sizer.dart';
 
 abstract class QuranViewStrategy {
   Widget buildView(QuranReadingState state, WidgetRef ref, BuildContext context);
@@ -596,31 +597,15 @@ class _QuranReadingScreenState extends ConsumerState<QuranReadingScreen> {
             switchQuranModeNode: _switchQuranModeNode);
         focusNodes.setupFocusTraversal(isPortrait: isPortrait);
 
-        if (isPortrait) {
-          return Stack(
-            children: [
-              // Main content
-              viewStrategy.buildView(state, ref, context),
-
-              // Controls overlay - show in both portrait and landscape
-              ...viewStrategy.buildControls(
-                context,
-                state,
-                userPrefs,
-                isPortrait,
-                focusNodes,
-                _scrollPageList,
-                _showPageSelector,
-              ),
-            ],
-          );
-        }
         return Stack(
           children: [
-            // Main content
-            viewStrategy.buildView(state, ref, context),
+            // Add padding container around main content
+            Padding(
+              padding: EdgeInsets.only(top: isPortrait ? 0 : 2.h), // Add top padding only in landscape mode
+              child: viewStrategy.buildView(state, ref, context),
+            ),
 
-            // Controls overlay - show in both portrait and landscape
+            // Controls overlay
             ...viewStrategy.buildControls(
               context,
               state,

--- a/lib/src/pages/quran/reading/quran_reading_screen.dart
+++ b/lib/src/pages/quran/reading/quran_reading_screen.dart
@@ -601,7 +601,7 @@ class _QuranReadingScreenState extends ConsumerState<QuranReadingScreen> {
           children: [
             // Add padding container around main content
             Padding(
-              padding: EdgeInsets.only(top: isPortrait ? 0 : 2.h), // Add top padding only in landscape mode
+              padding: EdgeInsets.only(top: isPortrait ? 0 : 1.h), // Add top padding only in landscape mode
               child: viewStrategy.buildView(state, ref, context),
             ),
 

--- a/lib/src/pages/quran/widget/reading/quran_surah_selector.dart
+++ b/lib/src/pages/quran/widget/reading/quran_surah_selector.dart
@@ -25,9 +25,8 @@ class SurahSelectorWidget extends ConsumerWidget {
     }
 
     final quranReadingState = ref.watch(quranReadingNotifierProvider);
-
     return Positioned(
-      top: 8,
+      top: 0.65.h,
       left: 0,
       right: 0,
       child: Center(
@@ -47,30 +46,24 @@ class SurahSelectorWidget extends ConsumerWidget {
               borderRadius: BorderRadius.circular(20),
               child: Builder(
                 builder: (context) {
-                  return ConstrainedBox(
-                    constraints: BoxConstraints(
-                      maxWidth: 22.w, // Limit width to 30% of screen
+                  return Container(
+                    padding: EdgeInsets.symmetric(
+                      horizontal: 2.w,
+                      vertical: 0.75.h,
                     ),
-                    child: Container(
-                      padding: EdgeInsets.symmetric(
-                        horizontal: 2.w,
-                        vertical: 1.h,
+                    decoration: BoxDecoration(
+                      color: Colors.black.withOpacity(0.6), // Increased opacity for better readability
+                      borderRadius: BorderRadius.circular(20),
+                    ),
+                    child: Text(
+                      state.currentSurahName,
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 7.sp,
+                        fontWeight: FontWeight.bold,
                       ),
-                      decoration: BoxDecoration(
-                        color: Colors.black.withOpacity(0.6), // Increased opacity for better readability
-                        borderRadius: BorderRadius.circular(20),
-                      ),
-                      child: Text(
-                        state.currentSurahName,
-                        style: TextStyle(
-                          color: Colors.white,
-                          fontSize: 7.sp,
-                          fontWeight: FontWeight.bold,
-                        ),
-                        textAlign: TextAlign.center,
-                        overflow: TextOverflow.ellipsis,
-                        maxLines: 1,
-                      ),
+                      textAlign: TextAlign.center,
+                      maxLines: 1,
                     ),
                   );
                 },

--- a/lib/src/pages/quran/widget/reading/quran_surah_selector.dart
+++ b/lib/src/pages/quran/widget/reading/quran_surah_selector.dart
@@ -47,18 +47,29 @@ class SurahSelectorWidget extends ConsumerWidget {
               borderRadius: BorderRadius.circular(20),
               child: Builder(
                 builder: (context) {
-                  return Container(
-                    padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                    decoration: BoxDecoration(
-                      color: Colors.black.withOpacity(0.4),
-                      borderRadius: BorderRadius.circular(20),
+                  return ConstrainedBox(
+                    constraints: BoxConstraints(
+                      maxWidth: 22.w, // Limit width to 30% of screen
                     ),
-                    child: Text(
-                      state.currentSurahName,
-                      style: TextStyle(
-                        color: Colors.white,
-                        fontSize: 8.sp,
-                        fontWeight: FontWeight.bold,
+                    child: Container(
+                      padding: EdgeInsets.symmetric(
+                        horizontal: 2.w,
+                        vertical: 1.h,
+                      ),
+                      decoration: BoxDecoration(
+                        color: Colors.black.withOpacity(0.6), // Increased opacity for better readability
+                        borderRadius: BorderRadius.circular(20),
+                      ),
+                      child: Text(
+                        state.currentSurahName,
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontSize: 7.sp,
+                          fontWeight: FontWeight.bold,
+                        ),
+                        textAlign: TextAlign.center,
+                        overflow: TextOverflow.ellipsis,
+                        maxLines: 1,
                       ),
                     ),
                   );

--- a/lib/src/pages/quran/widget/reading/quran_surah_selector.dart
+++ b/lib/src/pages/quran/widget/reading/quran_surah_selector.dart
@@ -59,7 +59,7 @@ class SurahSelectorWidget extends ConsumerWidget {
                       state.currentSurahName,
                       style: TextStyle(
                         color: Colors.white,
-                        fontSize: 7.sp,
+                        fontSize: 8.sp,
                         fontWeight: FontWeight.bold,
                       ),
                       textAlign: TextAlign.center,


### PR DESCRIPTION
📝 **Summary**
---
**This PR fixes** #1492 
--
#### **Problem**
The Surah selector overlaps the Quranic text, making it less readable. There is available space at the bottom of the screen that can be utilized to resolve this issue.

#### **Solution**
- Adjusted the position of the Surah selector by adding a margin at the top (`top: 0.65.h`) to move it further down.
- Improved padding for better alignment and spacing:
  - Horizontal padding set to `2.w`.
  - Vertical padding set to `0.75.h`.
- Increased the background opacity of the selector to `0.6` for better contrast without obscuring content.

---

#### **Impact**
- The Quran is no longer overlapped by the Surah selector.
- Improved readability and UI consistency.

![image](https://github.com/user-attachments/assets/5a80f7e1-2862-4721-b7b5-6bc72dd13635)

