### PR TITLE
fix: implement reciter caching with timestamp validation

### DIFF
--- a/lib/src/const/constants.dart
+++ b/lib/src/const/constants.dart
@@ -81,6 +81,8 @@ abstract class QuranConstant {
   static const String quranMoshafConfigJsonUrl = 'https://cdn.mawaqit.net/quran/tv_config.json';
   static const String kIsFirstTime = 'is_first_time_quran';
   static const String kQuranReciterImagesBaseUrl = 'https://cdn.mawaqit.net/quran/reciters-pictures/';
+  static const String kQuranCacheBoxName = 'timestamp_box';
+  static const String kQuranReciterRetentionTime = 'quran_reciter_retention_time';
 }
 
 abstract class AzkarConstant {

--- a/lib/src/data/data_source/quran/recite_remote_data_source.dart
+++ b/lib/src/data/data_source/quran/recite_remote_data_source.dart
@@ -148,17 +148,11 @@ class ReciteRemoteDataSource {
 }
 
 final reciteRemoteDataSourceProvider = Provider<ReciteRemoteDataSource>((ref) {
-  final dio = ref.watch(
-    dioProvider(
-      DioProviderParameter(
-        baseUrl: QuranConstant.kQuranBaseUrl,
-        interceptor: LogInterceptor(
-          requestBody: true,
-          responseBody: true,
-          logPrint: (l) => log('$l', name: 'API'),
-        ),
-      ),
-    ),
+  final dio = DioModule(
+    baseUrl: QuranConstant.kQuranBaseUrl,
+    headers: DioModule().defaultHeader,
+    connectTimeout: Duration(seconds: 30),
+    receiveTimeout: Duration(seconds: 30),
   );
   return ReciteRemoteDataSource(dio.dio);
 });

--- a/lib/src/module/dio_module.dart
+++ b/lib/src/module/dio_module.dart
@@ -57,9 +57,17 @@ class DioProviderParameter {
   /// [interceptor]: An optional interceptor for Dio.
   final Interceptor? interceptor;
 
+  /// [connectTimeout]: The connection timeout duration.
+  final Duration? connectTimeout;
+
+  /// [receiveTimeout]: The receive timeout duration.
+  final Duration? receiveTimeout;
+
   DioProviderParameter({
     required this.baseUrl,
     this.interceptor,
+    this.connectTimeout,
+    this.receiveTimeout,
   });
 }
 
@@ -67,9 +75,10 @@ class DioProviderParameter {
 /// It allows creating DioModule with different configurations throughout the app.
 final dioProvider = Provider.family<DioModule, DioProviderParameter>((ref, dioParameter) {
   return DioModule(
-    /// kStaticFilesUrl , kBaseUrl, kStaticFilesUrl
     baseUrl: dioParameter.baseUrl,
     headers: DioModule().defaultHeader,
     interceptor: dioParameter.interceptor,
+    connectTimeout: dioParameter.connectTimeout,
+    receiveTimeout: dioParameter.receiveTimeout,
   );
 });

--- a/lib/src/state_management/quran/recite/recite_notifier.dart
+++ b/lib/src/state_management/quran/recite/recite_notifier.dart
@@ -165,17 +165,12 @@ class ReciteNotifier extends AsyncNotifier<ReciteState> {
 
   Future<List<ReciterModel>> _getRemoteReciters() async {
     state = AsyncLoading();
-    try {
-      final reciteImpl = await ref.read(reciteImplProvider.future);
-      final sharedPreference = await ref.read(sharedPreferenceModule.future);
-      final languageCode = sharedPreference.getString('language_code') ?? 'en';
-      final mappedLanguage = LanguageHelper.mapLocaleWithQuran(languageCode);
-      final reciters = await reciteImpl.getAllReciters(language: mappedLanguage);
-      return reciters;
-    } catch (e, s) {
-      state = AsyncError(e, s);
-      rethrow;
-    }
+    final reciteImpl = await ref.read(reciteImplProvider.future);
+    final sharedPreference = await ref.read(sharedPreferenceModule.future);
+    final languageCode = sharedPreference.getString('language_code') ?? 'en';
+    final mappedLanguage = LanguageHelper.mapLocaleWithQuran(languageCode);
+    final reciters = await reciteImpl.getAllReciters(language: mappedLanguage);
+    return reciters;
   }
 
   Future<List<ReciterModel>> _getAllReciters(List<ReciterModel> favorite, List<ReciterModel> reciters) async {


### PR DESCRIPTION
📝 **Summary**
---
**This PR fixes** 

**Description**
---
This PR introduces a caching mechanism for reciter data to improve performance and reduce unnecessary network calls. The changes include:

- Added a new Hive box (`_timestampBox`) to track the last update time of reciter data.
- Implemented a 30-day cache retention period in `ReciteImpl` to ensure data is refreshed only when outdated.
- Added a `getLastUpdatedTimestamp` method to retrieve the cache timestamp.
- Updated `reciteLocalDataSourceProvider` to include the new `_timestampBox`.
- Modified `reciteRemoteDataSourceProvider` to use a direct `DioModule` instance for simplicity.
- Removed redundant try-catch blocks in `_getRemoteReciters` for cleaner code flow.
- Added new constants (`kQuranCacheBoxName` and `kQuranReciterRetentionTime`) for better maintainability.

These changes ensure that reciter data is cached locally and refreshed only when necessary, improving the app's performance and user experience.

**Tests**
---
🧪 **Use case 1**
---
💬 **Description:**
Launch the app and verify that reciter data is fetched from the cache if it was updated within the last 30 days. If the cache is outdated, ensure the data is fetched from the remote API and the cache is updated.

📷 **Screenshots or GIFs (if applicable):**
N/A

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).