### PR TITLE
fix: remove the FlexFit from loose into tight

### DIFF
--- a/lib/src/widgets/display_text_widget.dart
+++ b/lib/src/widgets/display_text_widget.dart
@@ -157,7 +157,7 @@ class DisplayTextWidget extends ConsumerWidget {
     Duration? delay,
   }) {
     return Flexible(
-      fit: isHadith ? FlexFit.tight : FlexFit.loose,
+      fit: FlexFit.loose,
       child: Container(
         constraints: BoxConstraints(maxHeight: maxHeight.vh),
         child: Padding(


### PR DESCRIPTION
it solves #1519 

This pull request includes a change to the `DisplayTextWidget` class in the `lib/src/widgets/display_text_widget.dart` file. The change modifies the `Flexible` widget's `fit` property to always use `FlexFit.loose`, regardless of the value of the `isHadith` parameter.

* [`lib/src/widgets/display_text_widget.dart`](diffhunk://#diff-94353a14febc7a020f51ac92838b4cfe0e7c404b381b55adf375592079f2c84aL160-R160): Modified the `fit` property of the `Flexible` widget to always use `FlexFit.loose` instead of conditionally using `FlexFit.tight` based on the `isHadith` parameter.

![image](https://github.com/user-attachments/assets/77f00c36-728c-45b5-81da-2b463e456f50)

