### PR TITLE
fix: add mounted in `addPostFrameCallback`

### DIFF
--- a/lib/src/pages/quran/page/reciter_selection_screen.dart
+++ b/lib/src/pages/quran/page/reciter_selection_screen.dart
@@ -148,7 +148,9 @@ class _ReciterSelectionScreenState extends ConsumerState<ReciterSelectionScreen>
       }
     });
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      ref.read(reciteNotifierProvider.notifier);
+      if (mounted) {
+        ref.read(reciteNotifierProvider.notifier);
+      }
       _setInitialFocus();
     });
   }


### PR DESCRIPTION
this issue: #1430 

This pull request includes a small change to the `lib/src/pages/quran/page/reciter_selection_screen.dart` file. The change ensures that the `reciteNotifierProvider` is read only if the widget is mounted.
