### PR TITLE
fix: update Fajr Wake Up screen text alignment to two lines

### DIFF
--- a/lib/src/pages/home/sub_screens/fajr_wake_up_screen.dart
+++ b/lib/src/pages/home/sub_screens/fajr_wake_up_screen.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:mawaqit/i18n/l10n.dart';
@@ -70,22 +71,20 @@ class _FajrWakeUpSubScreenState extends State<FajrWakeUpSubScreen> {
                       color: Colors.white,
                     ).animate().slideX(begin: -2).addRepaintBoundary(),
                     Flexible(
-                      fit: FlexFit.loose,
-                      flex: 1,
+                      flex: 2,
                       child: Padding(
                         padding: const EdgeInsets.all(20.0),
-                        child: FittedBox(
-                          child: Text(
-                            S.of(context).salatKhayrMinaNawm,
-                            style: TextStyle(
-                              fontWeight: FontWeight.bold,
-                              fontSize: 14.vw,
-                              // height: 2,
-                              color: Colors.white,
-                              shadows: kHomeTextShadow,
-                            ),
-                          ).animate().slideY(begin: -1, delay: .5.seconds).fadeIn().addRepaintBoundary(),
-                        ),
+                        child: AutoSizeText(
+                          S.of(context).salatKhayrMinaNawm,
+                          maxLines: 2,
+                          textAlign: TextAlign.center, // Added text alignment
+                          style: TextStyle(
+                            fontWeight: FontWeight.bold,
+                            fontSize: 8.vw,
+                            color: Colors.white,
+                            shadows: kHomeTextShadow,
+                          ),
+                        ).animate().slideY(begin: -1, delay: .5.seconds).fadeIn().addRepaintBoundary(),
                       ),
                     ),
                     Icon(


### PR DESCRIPTION
This pull request includes changes to the `fajr_wake_up_screen.dart` file to improve text rendering and alignment. The most important changes include the addition of the `auto_size_text` package for better text scaling and modifications to the `Flexible` widget properties.

Improvements to text rendering and alignment:

* [`lib/src/pages/home/sub_screens/fajr_wake_up_screen.dart`](diffhunk://#diff-c7311af808a7b0f5f4d66d5bda635513337323061af1b22918630ae7c1dca0f5R1): Added the `auto_size_text` package import for improved text scaling.
* Modified the `Flexible` widget to use `AutoSizeText` instead of `FittedBox` and `Text`, allowing for better control over text size and alignment.

Widget properties adjustments:

* Changed the `flex` property of the `Flexible` widget from `1` to `2` to adjust layout proportions.
* Added `maxLines: 2` and `textAlign: TextAlign.center` to `AutoSizeText` for improved text readability and alignment.
* Adjusted the `fontSize` property in the `TextStyle` from `14.vw` to `8.vw` for better scaling.