### PR TITLE
feat: add more debugging screens

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -425,5 +425,6 @@
   "selectMoshaf": "Select a Mushaf",
   "randomSurahSelection": "Random Surah Selection",
   "selectSurah": "Select a Surah",
-  "initializingAutoReading": "Initializing in progress..."
+  "initializingAutoReading": "Initializing in progress...",
+  "duaBetweenAdhanIqamah": "Supplication (Du'a) is not rejected between the Adhan and Iqamah."
 }

--- a/lib/src/developer_mode/DrawerListTest.dart
+++ b/lib/src/developer_mode/DrawerListTest.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:mawaqit/i18n/l10n.dart';
 import 'package:mawaqit/src/pages/HomeScreen.dart';
 import 'package:mawaqit/src/pages/developer/DeveloperScreen.dart';
+import 'package:mawaqit/src/pages/home/sub_screens/DuaaBetweenAdhanAndIqama.dart';
+import 'package:mawaqit/src/pages/home/sub_screens/DuaaEftarScreen.dart';
+import 'package:mawaqit/src/pages/home/sub_screens/takberat_aleid_screen.dart';
 import 'package:mawaqit/src/services/user_preferences_manager.dart';
 import 'package:provider/provider.dart';
 
@@ -61,6 +64,39 @@ class DrawerListDeveloper extends StatelessWidget {
             AppRouter.popAndPush(MosqueBackgroundScreen(
               child: NormalHomeSubScreen(),
             ));
+          },
+        ),
+        DrawerListTitle(
+          icon: Icons.timer_rounded,
+          text: S.of(context).eidMubarak,
+          onTap: () {
+            AppRouter.popAndPush(
+              MosqueBackgroundScreen(
+                child: TakberatAleidScreen(),
+              ),
+            );
+          },
+        ),
+        DrawerListTitle(
+          icon: Icons.timer_rounded,
+          text: S.of(context).duaaElEftar,
+          onTap: () {
+            AppRouter.popAndPush(
+              MosqueBackgroundScreen(
+                child: DuaaEftarScreen(),
+              ),
+            );
+          },
+        ),
+        DrawerListTitle(
+          icon: Icons.timer_rounded,
+          text: S.of(context).duaBetweenAdhanIqamah,
+          onTap: () {
+            AppRouter.popAndPush(
+              MosqueBackgroundScreen(
+                child: DuaaBetweenAdhanAndIqamaaScreen(),
+              ),
+            );
           },
         ),
         DrawerListTitle(


### PR DESCRIPTION
📝 **Summary**
---
**This PR fixes**  #1534 

**Description**
---
This PR adds three debug-only screens to the drawer for rapid testing of mosque-related features. The screens include:

- **Eid Mubarak Screen:** Opens the `TakberatAleidScreen` wrapped in `MosqueBackgroundScreen`.
- **Duaa Eftar Screen:** Opens the `DuaaEftarScreen` wrapped in `MosqueBackgroundScreen`.
- **Duaa Between Adhan & Iqamah Screen:** Opens the `DuaaBetweenAdhanAndIqamaaScreen` wrapped in `MosqueBackgroundScreen`.

Each screen is accessible via a `DrawerListTitle` widget using the timer icon and localized text. These entries are enabled only in debug mode to ensure they do not appear in production builds.

**Tests**
---
🧪 **Use case 1**
---
💬 **Description:**
- Open the debug drawer in the app.
- Tap on the **Eid Mubarak** entry to navigate to the `TakberatAleidScreen` within the mosque background.
- Tap on the **Duaa Eftar** entry to navigate to the `DuaaEftarScreen` within the mosque background.
- Tap on the **Duaa Between Adhan & Iqamah** entry to navigate to the `DuaaBetweenAdhanAndIqamaaScreen` within the mosque background.

📷 **Screenshots or GIFs (if applicable):**

![Screen Recording 2025-02-08 at 9 18 03 PM](https://github.com/user-attachments/assets/960f9858-994d-46e5-80a4-57f5a5a171fa)

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).