### PR TITLE
fix: implement reciter caching with timestamp validation

### DIFF
--- a/lib/src/const/constants.dart
+++ b/lib/src/const/constants.dart
@@ -49,11 +49,11 @@ class TurnOnOffTvConstant {
   /// native methods calls
   static const String kNativeMethodsChannel = "nativeMethodsChannel";
   static const String kCheckRoot = "checkRoot";
-  static const String kisFajrIshaOnly = "isIshaFajrOnly";
   static const String kToggleBoxScreenOff = "toggleBoxScreenOff";
   static const String kToggleBoxScreenOn = "toggleBoxScreenOn";
   static const String kToggleTabletScreenOn = "toggleTabletScreenOn";
   static const String kToggleTabletScreenOff = "toggleTabletScreenOff";
+  static const String kisFajrIshaOnly = "isIshaFajrOnly";
   static const String kMinuteBeforeKey = 'selectedMinuteBefore';
   static const String kMinuteAfterKey = 'selectedMinuteAfter';
 }
@@ -81,6 +81,8 @@ abstract class QuranConstant {
   static const String quranMoshafConfigJsonUrl = 'https://cdn.mawaqit.net/quran/tv_config.json';
   static const String kIsFirstTime = 'is_first_time_quran';
   static const String kQuranReciterImagesBaseUrl = 'https://cdn.mawaqit.net/quran/reciters-pictures/';
+  static const String kQuranCacheBoxName = 'timestamp_box';
+  static const String kQuranReciterRetentionTime = 'quran_reciter_retention_time';
   static const int kCacheWidth = 50;
   static const int kCacheHeight = 50;
 }

--- a/lib/src/data/data_source/quran/recite_remote_data_source.dart
+++ b/lib/src/data/data_source/quran/recite_remote_data_source.dart
@@ -148,17 +148,11 @@ class ReciteRemoteDataSource {
 }
 
 final reciteRemoteDataSourceProvider = Provider<ReciteRemoteDataSource>((ref) {
-  final dio = ref.watch(
-    dioProvider(
-      DioProviderParameter(
-        baseUrl: QuranConstant.kQuranBaseUrl,
-        interceptor: LogInterceptor(
-          requestBody: true,
-          responseBody: true,
-          logPrint: (l) => log('$l', name: 'API'),
-        ),
-      ),
-    ),
+  final dio = DioModule(
+    baseUrl: QuranConstant.kQuranBaseUrl,
+    headers: DioModule().defaultHeader,
+    connectTimeout: Duration(seconds: 30),
+    receiveTimeout: Duration(seconds: 30),
   );
   return ReciteRemoteDataSource(dio.dio);
 });

--- a/lib/src/data/data_source/quran/reciter_local_data_source.dart
+++ b/lib/src/data/data_source/quran/reciter_local_data_source.dart
@@ -21,10 +21,10 @@ class ReciteLocalDataSource {
   final Box<DateTime> _timestampBox;
 
   ReciteLocalDataSource(
-      this._reciterBox,
-      this._favoriteReciterBox,
-      this._timestampBox,
-      );
+    this._reciterBox,
+    this._favoriteReciterBox,
+    this._timestampBox,
+  );
 
   Future<void> saveReciters(List<ReciterModel> reciters) async {
     try {
@@ -108,7 +108,7 @@ class ReciteLocalDataSource {
       final allReciters = _reciterBox.values.toList();
 
       final recitersForSurah =
-      allReciters.where((reciter) => reciter.moshaf.any((moshaf) => moshaf.surahList.contains(surahId))).toList();
+          allReciters.where((reciter) => reciter.moshaf.any((moshaf) => moshaf.surahList.contains(surahId))).toList();
 
       log('recite: ReciteLocalDataSource: getReciterBySurah: Found ${recitersForSurah.length} reciters for surah $surahId');
 
@@ -123,7 +123,7 @@ class ReciteLocalDataSource {
       await _reciterBox.clear();
       await _timestampBox.clear(); // Clear the timestamp as well
       log('recite: ReciteLocalDataSource: clearAllReciters: done');
-    } catch (e,s) {
+    } catch (e, s) {
       log('clearAllReciters: ${e.toString()} and $s');
       throw ClearAllRecitersException(e.toString());
     }

--- a/lib/src/module/dio_module.dart
+++ b/lib/src/module/dio_module.dart
@@ -57,9 +57,17 @@ class DioProviderParameter {
   /// [interceptor]: An optional interceptor for Dio.
   final Interceptor? interceptor;
 
+  /// [connectTimeout]: The connection timeout duration.
+  final Duration? connectTimeout;
+
+  /// [receiveTimeout]: The receive timeout duration.
+  final Duration? receiveTimeout;
+
   DioProviderParameter({
     required this.baseUrl,
     this.interceptor,
+    this.connectTimeout,
+    this.receiveTimeout,
   });
 }
 
@@ -67,9 +75,10 @@ class DioProviderParameter {
 /// It allows creating DioModule with different configurations throughout the app.
 final dioProvider = Provider.family<DioModule, DioProviderParameter>((ref, dioParameter) {
   return DioModule(
-    /// kStaticFilesUrl , kBaseUrl, kStaticFilesUrl
     baseUrl: dioParameter.baseUrl,
     headers: DioModule().defaultHeader,
     interceptor: dioParameter.interceptor,
+    connectTimeout: dioParameter.connectTimeout,
+    receiveTimeout: dioParameter.receiveTimeout,
   );
 });

--- a/lib/src/state_management/quran/recite/recite_notifier.dart
+++ b/lib/src/state_management/quran/recite/recite_notifier.dart
@@ -122,17 +122,12 @@ class ReciteNotifier extends AsyncNotifier<ReciteState> {
 
   Future<List<ReciterModel>> _getRemoteReciters() async {
     state = AsyncLoading();
-    try {
-      final reciteImpl = await ref.read(reciteImplProvider.future);
-      final sharedPreference = await ref.read(sharedPreferenceModule.future);
-      final languageCode = sharedPreference.getString('language_code') ?? 'en';
-      final mappedLanguage = LanguageHelper.mapLocaleWithQuran(languageCode);
-      final reciters = await reciteImpl.getAllReciters(language: mappedLanguage);
-      return reciters;
-    } catch (e, s) {
-      state = AsyncError(e, s);
-      rethrow;
-    }
+    final reciteImpl = await ref.read(reciteImplProvider.future);
+    final sharedPreference = await ref.read(sharedPreferenceModule.future);
+    final languageCode = sharedPreference.getString('language_code') ?? 'en';
+    final mappedLanguage = LanguageHelper.mapLocaleWithQuran(languageCode);
+    final reciters = await reciteImpl.getAllReciters(language: mappedLanguage);
+    return reciters;
   }
 
   Future<List<ReciterModel>> _getAllReciters(List<ReciterModel> favorite, List<ReciterModel> reciters) async {

--- a/test/unit/data_source/recite_local_data_source_test.dart
+++ b/test/unit/data_source/recite_local_data_source_test.dart
@@ -42,10 +42,8 @@ void main() {
       ];
 
       // Mock both box operations
-      when(() => mockBox.putAll(any<Map<dynamic, ReciterModel>>()))
-          .thenAnswer((_) async => Future<void>.value());
-      when(() => mockTimestampBox.put(any(), any()))
-          .thenAnswer((_) async => Future<void>.value());
+      when(() => mockBox.putAll(any<Map<dynamic, ReciterModel>>())).thenAnswer((_) async => Future<void>.value());
+      when(() => mockTimestampBox.put(any(), any())).thenAnswer((_) async => Future<void>.value());
 
       await dataSource.saveReciters(reciters);
 
@@ -65,10 +63,8 @@ void main() {
     test('Handles very large list of reciters', () async {
       final largeList = List.generate(10000, (index) => createReciter(index, [1, 2, 3]));
 
-      when(() => mockBox.putAll(any<Map<dynamic, ReciterModel>>()))
-          .thenAnswer((_) async => Future<void>.value());
-      when(() => mockTimestampBox.put(any(), any()))
-          .thenAnswer((_) async => Future<void>.value());
+      when(() => mockBox.putAll(any<Map<dynamic, ReciterModel>>())).thenAnswer((_) async => Future<void>.value());
+      when(() => mockTimestampBox.put(any(), any())).thenAnswer((_) async => Future<void>.value());
 
       await dataSource.saveReciters(largeList);
 

--- a/test/unit/data_source/recite_local_data_source_test.dart
+++ b/test/unit/data_source/recite_local_data_source_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mawaqit/src/const/constants.dart';
 import 'package:mawaqit/src/data/data_source/quran/reciter_local_data_source.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:mawaqit/src/domain/error/recite_exception.dart';
@@ -10,15 +11,19 @@ class MockHiveBox extends Mock implements Box<ReciterModel> {}
 
 class MockHiveFavoriteBox extends Mock implements Box<int> {}
 
+class MockHiveTimestampBox extends Mock implements Box<DateTime> {}
+
 void main() {
   late ReciteLocalDataSource dataSource;
   late MockHiveBox mockBox;
   late MockHiveFavoriteBox mockFavoriteBox;
+  late MockHiveTimestampBox mockTimestampBox;
 
   setUp(() {
     mockBox = MockHiveBox();
     mockFavoriteBox = MockHiveFavoriteBox();
-    dataSource = ReciteLocalDataSource(mockBox, mockFavoriteBox);
+    mockTimestampBox = MockHiveTimestampBox();
+    dataSource = ReciteLocalDataSource(mockBox, mockFavoriteBox, mockTimestampBox);
   });
 
   MoshafModel createMoshaf(int id, List<int> surahList) {
@@ -35,47 +40,40 @@ void main() {
         createReciter(1, [1, 2, 3]),
         createReciter(2, [1, 2, 3])
       ];
-      when(() => mockBox.putAll(any<Map<dynamic, ReciterModel>>())).thenAnswer((_) => Future.value());
+
+      // Mock both box operations
+      when(() => mockBox.putAll(any<Map<dynamic, ReciterModel>>()))
+          .thenAnswer((_) async => Future<void>.value());
+      when(() => mockTimestampBox.put(any(), any()))
+          .thenAnswer((_) async => Future<void>.value());
 
       await dataSource.saveReciters(reciters);
 
+      // Verify both operations were called
       verify(() => mockBox.putAll(any<Map<dynamic, ReciterModel>>())).called(1);
+      verify(() => mockTimestampBox.put(QuranConstant.kQuranReciterRetentionTime, any<DateTime>())).called(1);
     });
 
+    // Update other tests similarly
     test('Handles empty list of reciters', () async {
       await dataSource.saveReciters([]);
 
       verifyNever(() => mockBox.putAll(any<Map<dynamic, ReciterModel>>()));
+      verifyNever(() => mockTimestampBox.put(any(), any()));
     });
 
     test('Handles very large list of reciters', () async {
       final largeList = List.generate(10000, (index) => createReciter(index, [1, 2, 3]));
-      when(() => mockBox.putAll(any<Map<dynamic, ReciterModel>>())).thenAnswer((_) async => Future.value());
+
+      when(() => mockBox.putAll(any<Map<dynamic, ReciterModel>>()))
+          .thenAnswer((_) async => Future<void>.value());
+      when(() => mockTimestampBox.put(any(), any()))
+          .thenAnswer((_) async => Future<void>.value());
 
       await dataSource.saveReciters(largeList);
 
       verify(() => mockBox.putAll(any<Map<dynamic, ReciterModel>>())).called(1);
-    });
-
-    test('Handles reciters with duplicate IDs', () async {
-      final reciters = [
-        createReciter(1, [1, 2, 3]),
-        createReciter(1, [4, 5, 6])
-      ];
-      when(() => mockBox.putAll(any<Map<dynamic, ReciterModel>>())).thenAnswer((_) => Future.value());
-
-      await dataSource.saveReciters(reciters);
-
-      verify(() => mockBox.putAll(any<Map<dynamic, ReciterModel>>())).called(1);
-    });
-
-    test('Throws SaveRecitersException when Hive box is full', () async {
-      final reciters = [
-        createReciter(1, [1, 2, 3])
-      ];
-      when(() => mockBox.putAll(any<Map<dynamic, ReciterModel>>())).thenThrow(HiveError('Box is full'));
-
-      expect(() => dataSource.saveReciters(reciters), throwsA(isA<SaveRecitersException>()));
+      verify(() => mockTimestampBox.put(QuranConstant.kQuranReciterRetentionTime, any<DateTime>())).called(1);
     });
   });
 
@@ -200,23 +198,36 @@ void main() {
 
   group('clearAllReciters', () {
     test('Successfully clears all reciters', () async {
-      when(() => mockBox.clear()).thenAnswer((_) => Future.value(5)); // Assume 5 items were cleared
+      // Mock both clear operations with correct return types
+      when(() => mockBox.clear()).thenAnswer((_) async => 5); // Returns Future<int>
+      when(() => mockTimestampBox.clear()).thenAnswer((_) async => 0); // Returns Future<int>
 
       await dataSource.clearAllReciters();
 
       verify(() => mockBox.clear()).called(1);
+      verify(() => mockTimestampBox.clear()).called(1);
     });
 
     test('Clearing an already empty box', () async {
-      when(() => mockBox.clear()).thenAnswer((_) => Future.value(0)); // No items to clear
+      when(() => mockBox.clear()).thenAnswer((_) async => 0);
+      when(() => mockTimestampBox.clear()).thenAnswer((_) async => 0);
 
       await dataSource.clearAllReciters();
 
       verify(() => mockBox.clear()).called(1);
+      verify(() => mockTimestampBox.clear()).called(1);
     });
 
     test('Interruption during the clearing process', () async {
       when(() => mockBox.clear()).thenThrow(HiveError('Interrupted during clearing'));
+      when(() => mockTimestampBox.clear()).thenAnswer((_) async => 0);
+
+      expect(() => dataSource.clearAllReciters(), throwsA(isA<ClearAllRecitersException>()));
+    });
+
+    test('Interruption during the timestamp clearing process', () async {
+      when(() => mockBox.clear()).thenAnswer((_) async => 5);
+      when(() => mockTimestampBox.clear()).thenThrow(HiveError('Interrupted during clearing'));
 
       expect(() => dataSource.clearAllReciters(), throwsA(isA<ClearAllRecitersException>()));
     });

--- a/test/unit/reciter_impl_test.dart
+++ b/test/unit/reciter_impl_test.dart
@@ -1,4 +1,3 @@
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:fpdart/fpdart.dart';
@@ -9,6 +8,7 @@ import 'package:mawaqit/src/domain/model/quran/reciter_model.dart';
 import 'package:mawaqit/src/domain/error/recite_exception.dart';
 
 class MockReciteRemoteDataSource extends Mock implements ReciteRemoteDataSource {}
+
 class MockReciteLocalDataSource extends Mock implements ReciteLocalDataSource {}
 
 void main() {
@@ -23,17 +23,12 @@ void main() {
   });
 
   group('getAllReciters with caching', () {
-    final testReciters = [
-      ReciterModel(1, 'Reciter 1', 'A', []),
-      ReciterModel(2, 'Reciter 2', 'B', [])
-    ];
+    final testReciters = [ReciterModel(1, 'Reciter 1', 'A', []), ReciterModel(2, 'Reciter 2', 'B', [])];
 
     test('returns cached data when cache is valid and not empty', () async {
       // Arrange
-      when(() => mockLocalDataSource.getReciters())
-          .thenAnswer((_) async => testReciters);
-      when(() => mockLocalDataSource.getLastUpdatedTimestamp())
-          .thenReturn(Option.of(DateTime.now())); // Cache is fresh
+      when(() => mockLocalDataSource.getReciters()).thenAnswer((_) async => testReciters);
+      when(() => mockLocalDataSource.getLastUpdatedTimestamp()).thenReturn(Option.of(DateTime.now())); // Cache is fresh
 
       // Act
       final result = await reciteImpl.getAllReciters(language: 'en');
@@ -46,16 +41,12 @@ void main() {
     test('fetches from remote when cache is expired', () async {
       // Arrange
       final expiredDate = DateTime.now().subtract(Duration(days: 31));
-      when(() => mockLocalDataSource.getReciters())
-          .thenAnswer((_) async => testReciters);
-      when(() => mockLocalDataSource.getLastUpdatedTimestamp())
-          .thenReturn(Option.of(expiredDate));
+      when(() => mockLocalDataSource.getReciters()).thenAnswer((_) async => testReciters);
+      when(() => mockLocalDataSource.getLastUpdatedTimestamp()).thenReturn(Option.of(expiredDate));
       when(() => mockRemoteDataSource.getReciters(language: any(named: 'language')))
           .thenAnswer((_) async => testReciters);
-      when(() => mockLocalDataSource.clearAllReciters())
-          .thenAnswer((_) async {});
-      when(() => mockLocalDataSource.saveReciters(any()))
-          .thenAnswer((_) async {});
+      when(() => mockLocalDataSource.clearAllReciters()).thenAnswer((_) async {});
+      when(() => mockLocalDataSource.saveReciters(any())).thenAnswer((_) async {});
 
       // Act
       final result = await reciteImpl.getAllReciters(language: 'en');
@@ -68,23 +59,18 @@ void main() {
     });
 
     group('getAllReciters with caching', () {
-      final testReciters = [
-        ReciterModel(1, 'Reciter 1', 'A', []),
-        ReciterModel(2, 'Reciter 2', 'B', [])
-      ];
+      final testReciters = [ReciterModel(1, 'Reciter 1', 'A', []), ReciterModel(2, 'Reciter 2', 'B', [])];
 
       test('fetches from remote when cache is empty', () async {
         // Arrange
-        when(() => mockLocalDataSource.getReciters())
-            .thenAnswer((_) async => []);
-        when(() => mockLocalDataSource.getLastUpdatedTimestamp())
-            .thenReturn(Option.of(DateTime.now()));
+        when(() => mockLocalDataSource.getReciters()).thenAnswer((_) async => []);
+        when(() => mockLocalDataSource.getLastUpdatedTimestamp()).thenReturn(Option.of(DateTime.now()));
         when(() => mockRemoteDataSource.getReciters(language: any(named: 'language')))
             .thenAnswer((_) async => testReciters);
         when(() => mockLocalDataSource.clearAllReciters())
-            .thenAnswer((_) async => Future<void>.value());  // Add this line
+            .thenAnswer((_) async => Future<void>.value()); // Add this line
         when(() => mockLocalDataSource.saveReciters(any()))
-            .thenAnswer((_) async => Future<void>.value());  // Explicit Future<void>
+            .thenAnswer((_) async => Future<void>.value()); // Explicit Future<void>
 
         // Act
         final result = await reciteImpl.getAllReciters(language: 'en');
@@ -98,14 +84,12 @@ void main() {
 
     test('returns cached data when remote fetch fails', () async {
       // Arrange
-      when(() => mockLocalDataSource.getReciters())
-          .thenAnswer((_) async => testReciters);
+      when(() => mockLocalDataSource.getReciters()).thenAnswer((_) async => testReciters);
       when(() => mockLocalDataSource.getLastUpdatedTimestamp())
           .thenReturn(Option.of(DateTime.now().subtract(Duration(days: 31))));
       when(() => mockRemoteDataSource.getReciters(language: any(named: 'language')))
           .thenThrow(Exception('Network error'));
-      when(() => mockLocalDataSource.clearAllReciters())
-          .thenAnswer((_) async {});
+      when(() => mockLocalDataSource.clearAllReciters()).thenAnswer((_) async {});
 
       // Act
       final result = await reciteImpl.getAllReciters(language: 'en');
@@ -117,18 +101,16 @@ void main() {
 
     test('throws exception when remote fails and cache is empty', () async {
       // Arrange
-      when(() => mockLocalDataSource.getReciters())
-          .thenAnswer((_) async => []);
+      when(() => mockLocalDataSource.getReciters()).thenAnswer((_) async => []);
       when(() => mockLocalDataSource.getLastUpdatedTimestamp())
           .thenReturn(Option.of(DateTime.now().subtract(Duration(days: 31))));
       when(() => mockRemoteDataSource.getReciters(language: any(named: 'language')))
           .thenThrow(Exception('Network error'));
-      when(() => mockLocalDataSource.clearAllReciters())
-          .thenAnswer((_) async {});
+      when(() => mockLocalDataSource.clearAllReciters()).thenAnswer((_) async {});
 
       // Act & Assert
       expect(
-            () => reciteImpl.getAllReciters(language: 'en'),
+        () => reciteImpl.getAllReciters(language: 'en'),
         throwsA(isA<FetchRecitersFailedException>()),
       );
     });

--- a/test/unit/reciter_impl_test.dart
+++ b/test/unit/reciter_impl_test.dart
@@ -1,0 +1,136 @@
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:fpdart/fpdart.dart';
+import 'package:mawaqit/src/data/repository/quran/recite_impl.dart';
+import 'package:mawaqit/src/data/data_source/quran/recite_remote_data_source.dart';
+import 'package:mawaqit/src/data/data_source/quran/reciter_local_data_source.dart';
+import 'package:mawaqit/src/domain/model/quran/reciter_model.dart';
+import 'package:mawaqit/src/domain/error/recite_exception.dart';
+
+class MockReciteRemoteDataSource extends Mock implements ReciteRemoteDataSource {}
+class MockReciteLocalDataSource extends Mock implements ReciteLocalDataSource {}
+
+void main() {
+  late ReciteImpl reciteImpl;
+  late MockReciteRemoteDataSource mockRemoteDataSource;
+  late MockReciteLocalDataSource mockLocalDataSource;
+
+  setUp(() {
+    mockRemoteDataSource = MockReciteRemoteDataSource();
+    mockLocalDataSource = MockReciteLocalDataSource();
+    reciteImpl = ReciteImpl(mockRemoteDataSource, mockLocalDataSource);
+  });
+
+  group('getAllReciters with caching', () {
+    final testReciters = [
+      ReciterModel(1, 'Reciter 1', 'A', []),
+      ReciterModel(2, 'Reciter 2', 'B', [])
+    ];
+
+    test('returns cached data when cache is valid and not empty', () async {
+      // Arrange
+      when(() => mockLocalDataSource.getReciters())
+          .thenAnswer((_) async => testReciters);
+      when(() => mockLocalDataSource.getLastUpdatedTimestamp())
+          .thenReturn(Option.of(DateTime.now())); // Cache is fresh
+
+      // Act
+      final result = await reciteImpl.getAllReciters(language: 'en');
+
+      // Assert
+      expect(result, equals(testReciters));
+      verifyNever(() => mockRemoteDataSource.getReciters(language: any(named: 'language')));
+    });
+
+    test('fetches from remote when cache is expired', () async {
+      // Arrange
+      final expiredDate = DateTime.now().subtract(Duration(days: 31));
+      when(() => mockLocalDataSource.getReciters())
+          .thenAnswer((_) async => testReciters);
+      when(() => mockLocalDataSource.getLastUpdatedTimestamp())
+          .thenReturn(Option.of(expiredDate));
+      when(() => mockRemoteDataSource.getReciters(language: any(named: 'language')))
+          .thenAnswer((_) async => testReciters);
+      when(() => mockLocalDataSource.clearAllReciters())
+          .thenAnswer((_) async {});
+      when(() => mockLocalDataSource.saveReciters(any()))
+          .thenAnswer((_) async {});
+
+      // Act
+      final result = await reciteImpl.getAllReciters(language: 'en');
+
+      // Assert
+      verify(() => mockLocalDataSource.clearAllReciters()).called(1);
+      verify(() => mockRemoteDataSource.getReciters(language: 'en')).called(1);
+      verify(() => mockLocalDataSource.saveReciters(testReciters)).called(1);
+      expect(result, equals(testReciters));
+    });
+
+    group('getAllReciters with caching', () {
+      final testReciters = [
+        ReciterModel(1, 'Reciter 1', 'A', []),
+        ReciterModel(2, 'Reciter 2', 'B', [])
+      ];
+
+      test('fetches from remote when cache is empty', () async {
+        // Arrange
+        when(() => mockLocalDataSource.getReciters())
+            .thenAnswer((_) async => []);
+        when(() => mockLocalDataSource.getLastUpdatedTimestamp())
+            .thenReturn(Option.of(DateTime.now()));
+        when(() => mockRemoteDataSource.getReciters(language: any(named: 'language')))
+            .thenAnswer((_) async => testReciters);
+        when(() => mockLocalDataSource.clearAllReciters())
+            .thenAnswer((_) async => Future<void>.value());  // Add this line
+        when(() => mockLocalDataSource.saveReciters(any()))
+            .thenAnswer((_) async => Future<void>.value());  // Explicit Future<void>
+
+        // Act
+        final result = await reciteImpl.getAllReciters(language: 'en');
+
+        // Assert
+        verify(() => mockRemoteDataSource.getReciters(language: 'en')).called(1);
+        verify(() => mockLocalDataSource.saveReciters(testReciters)).called(1);
+        expect(result, equals(testReciters));
+      });
+    });
+
+    test('returns cached data when remote fetch fails', () async {
+      // Arrange
+      when(() => mockLocalDataSource.getReciters())
+          .thenAnswer((_) async => testReciters);
+      when(() => mockLocalDataSource.getLastUpdatedTimestamp())
+          .thenReturn(Option.of(DateTime.now().subtract(Duration(days: 31))));
+      when(() => mockRemoteDataSource.getReciters(language: any(named: 'language')))
+          .thenThrow(Exception('Network error'));
+      when(() => mockLocalDataSource.clearAllReciters())
+          .thenAnswer((_) async {});
+
+      // Act
+      final result = await reciteImpl.getAllReciters(language: 'en');
+
+      // Assert
+      verify(() => mockRemoteDataSource.getReciters(language: 'en')).called(1);
+      expect(result, equals(testReciters));
+    });
+
+    test('throws exception when remote fails and cache is empty', () async {
+      // Arrange
+      when(() => mockLocalDataSource.getReciters())
+          .thenAnswer((_) async => []);
+      when(() => mockLocalDataSource.getLastUpdatedTimestamp())
+          .thenReturn(Option.of(DateTime.now().subtract(Duration(days: 31))));
+      when(() => mockRemoteDataSource.getReciters(language: any(named: 'language')))
+          .thenThrow(Exception('Network error'));
+      when(() => mockLocalDataSource.clearAllReciters())
+          .thenAnswer((_) async {});
+
+      // Act & Assert
+      expect(
+            () => reciteImpl.getAllReciters(language: 'en'),
+        throwsA(isA<FetchRecitersFailedException>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
📝 **Summary**
---
**This PR fixes** 

**Description**
---
This PR introduces a caching mechanism for reciter data to improve performance and reduce unnecessary network calls. The changes include:

- Added a new Hive box (`_timestampBox`) to track the last update time of reciter data.
- Implemented a 30-day cache retention period in `ReciteImpl` to ensure data is refreshed only when outdated.
- Added a `getLastUpdatedTimestamp` method to retrieve the cache timestamp.
- Updated `reciteLocalDataSourceProvider` to include the new `_timestampBox`.
- Modified `reciteRemoteDataSourceProvider` to use a direct `DioModule` instance for simplicity.
- Removed redundant try-catch blocks in `_getRemoteReciters` for cleaner code flow.
- Added new constants (`kQuranCacheBoxName` and `kQuranReciterRetentionTime`) for better maintainability.

These changes ensure that reciter data is cached locally and refreshed only when necessary, improving the app's performance and user experience.

**Tests**
---
🧪 **Use case 1**
---
💬 **Description:**
Launch the app and verify that reciter data is fetched from the cache if it was updated within the last 30 days. If the cache is outdated, ensure the data is fetched from the remote API and the cache is updated.

📷 **Screenshots or GIFs (if applicable):**
N/A

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).