### PR TITLE
fix: standardize putAll definition in recite_local_data_source_test

### DIFF
--- a/test/unit/data_source/recite_local_data_source_test.dart
+++ b/test/unit/data_source/recite_local_data_source_test.dart
@@ -377,7 +377,10 @@ void main() {
 
       // Mock the main reciter box
       when(() => mockBox.values).thenReturn([oldReciter]);
-      when(() => mockBox.putAll(any())).thenAnswer((_) => Future<void>.value());
+
+      // Use only one definition for putAll - choose the style that works in other tests
+      when(() => mockBox.putAll(any<Map<dynamic, ReciterModel>>())).thenAnswer((_) => Future<void>.value());
+      when(() => mockTimestampBox.put(any(), any())).thenAnswer((_) => Future<void>.value());
 
       // Mock the favorite box
       when(() => mockFavoriteBox.values).thenReturn([1]);


### PR DESCRIPTION
This pull request includes a minor change to the `test/unit/data_source/recite_local_data_source_test.dart` file. The change involves updating the mock setup for the `putAll` method and adding a new mock setup for the `put` method in `mockTimestampBox`.

* [`test/unit/data_source/recite_local_data_source_test.dart`](diffhunk://#diff-1df4d44c953f65efe10f76bbdedbd62761bd6acb80b893f881ae0cb37c53f364L380-R383): Updated the mock setup for `putAll` to use a specific type and added a new mock setup for `put` in `mockTimestampBox`.