### PR TITLE
fix: Update Static Files to Use CDN and Adjust Audio Paths and the hadith xml

### DIFF
--- a/lib/src/const/constants.dart
+++ b/lib/src/const/constants.dart
@@ -7,8 +7,8 @@ const kDeviceInfo = 'device_info';
 
 const kBaseUrl = 'https://mawaqit.net/api';
 const kStagingUrl = 'https://staging.mawaqit.net/api';
-const kStaticFilesUrl = 'https://mawaqit.net/static';
-const kStagingStaticFilesUrl = 'https://staging.mawaqit.net/static';
+const kStaticFilesUrl = 'https://cdn.mawaqit.net';
+const kStagingStaticFilesUrl = 'https://cdn.mawaqit.net';
 
 const kApiToken = String.fromEnvironment('mawaqit.api.key');
 const kSentryDns = String.fromEnvironment('mawaqit.sentry.dns');

--- a/lib/src/data/data_source/random_hadith_remote_data_source.dart
+++ b/lib/src/data/data_source/random_hadith_remote_data_source.dart
@@ -47,7 +47,7 @@ class RandomHadithRemoteDataSource {
   }) async {
     log('random_hadith: RandomHadithRemoteDataSource: Fetching random hadith XML', time: DateTime.now());
     try {
-      final response = await staticDio.get('/xml/ahadith/$language.xml');
+      final response = await staticDio.get('/ahadith/$language.xml');
       final List<XmlElement>? hadithXML = await Isolate.run(
         () async {
           log('random_hadith: RandomHadithRemoteDataSource: start xml fetch', time: DateTime.now());

--- a/lib/src/helpers/Api.dart
+++ b/lib/src/helpers/Api.dart
@@ -204,7 +204,7 @@ class Api {
 
   /// prepare the data to be cached
   static Future<void> cacheHadithXMLFiles({String language = 'ar'}) =>
-      Future.wait(language.split('-').map((e) => dioStatic.get('/xml/ahadith/$e.xml')));
+      Future.wait(language.split('-').map((e) => dioStatic.get('/ahadith/$e.xml')));
 
   /// get the hadith file from the static server and cache it
   /// return random hadith from the file
@@ -214,7 +214,7 @@ class Api {
 
     /// this should be called only on offline mode so it should hit the cache
 
-    final response = await dioStatic.get('/xml/ahadith/$language.xml');
+    final response = await dioStatic.get('/ahadith/$language.xml');
 
     final document = XmlDocument.parse(response.data);
 

--- a/lib/src/pages/home/widgets/footer.dart
+++ b/lib/src/pages/home/widgets/footer.dart
@@ -10,7 +10,7 @@ import 'package:mawaqit/src/pages/home/widgets/FlashWidget.dart';
 import 'package:mawaqit/src/pages/home/widgets/HomeLogoVersion.dart';
 import 'package:mawaqit/src/pages/home/widgets/MosqueInformationWidget.dart';
 
-const kFooterQrLink = 'https://mawaqit.net/static/images/store-qrcode.png?4.89.2';
+const kFooterQrLink = 'https://cdn.mawaqit.net/images/store-qrcode.png?4.89.2';
 
 class Footer extends StatelessWidget {
   const Footer({Key? key}) : super(key: key);

--- a/lib/src/services/audio_manager.dart
+++ b/lib/src/services/audio_manager.dart
@@ -14,9 +14,9 @@ import '../../main.dart';
 import 'audio_stream_offline_manager.dart';
 
 class AudioManager extends ChangeNotifier {
-  String bipLink = "$kStaticFilesUrl/mp3/bip.mp3";
+  String bipLink = "$kStaticFilesUrl/audio/bip.mp3";
 
-  String duaAfterAdhanLink = "$kStaticFilesUrl/mp3/duaa-after-adhan.mp3";
+  String duaAfterAdhanLink = "$kStaticFilesUrl/audio/duaa-after-adhan.mp3";
 
   late AudioPlayer player;
 
@@ -33,9 +33,9 @@ class AudioManager extends ChangeNotifier {
   late final dio = Dio()..interceptors.add(DioCacheInterceptor(options: option));
 
   String adhanLink(MosqueConfig? mosqueConfig, {bool useFajrAdhan = false}) {
-    String adhanLink = "$kStaticFilesUrl/mp3/adhan-afassy.mp3";
+    String adhanLink = "$kStaticFilesUrl/audio/adhan-afassy.mp3";
     if (mosqueConfig!.adhanVoice?.isNotEmpty ?? false) {
-      adhanLink = "$kStaticFilesUrl/mp3/${mosqueConfig.adhanVoice!}.mp3";
+      adhanLink = "$kStaticFilesUrl/audio/${mosqueConfig.adhanVoice!}.mp3";
     }
 
     if (useFajrAdhan && !adhanLink.contains('bip')) {
@@ -44,7 +44,6 @@ class AudioManager extends ChangeNotifier {
 
     return adhanLink;
   }
-
   void loadAndPlayAdhanVoice(
     MosqueConfig? mosqueConfig, {
     VoidCallback? onDone,
@@ -79,10 +78,8 @@ class AudioManager extends ChangeNotifier {
     try {
       await player.setAsset(assets);
       player.play();
-      log('audio: AudioManager: loadAssetsAndPlay: playing audio file');
       player.playerStateStream.listen((state) {
         if (state.processingState == ProcessingState.completed) {
-          log('audio: AudioManager: loadAssetsAndPlay: done playing audio file');
           onDone?.call();
         }
       });
@@ -121,7 +118,6 @@ class AudioManager extends ChangeNotifier {
       player.play();
       player.playerStateStream.listen((state) {
         if (state.processingState == ProcessingState.completed) {
-          log('audio: AudioManager: loadAndPlay: done playing audio file');
           onDone?.call();
         }
       });

--- a/lib/src/services/audio_manager.dart
+++ b/lib/src/services/audio_manager.dart
@@ -44,6 +44,7 @@ class AudioManager extends ChangeNotifier {
 
     return adhanLink;
   }
+
   void loadAndPlayAdhanVoice(
     MosqueConfig? mosqueConfig, {
     VoidCallback? onDone,

--- a/lib/src/services/notification/prayer_schedule_service.dart
+++ b/lib/src/services/notification/prayer_schedule_service.dart
@@ -370,14 +370,17 @@ class PrayerScheduleService {
   }
 
   static String getAdhanLink(MosqueConfig? mosqueConfig, {bool useFajrAdhan = false}) {
-    String baseLink = "$kStaticFilesUrl/mp3/adhan-afassy.mp3";
+    String baseLink = "$kStaticFilesUrl/audio/adhan-afassy.mp3";
+    logger.d('[StaticFileURL] PrayerScheduleService: Base adhan link using static URL: $baseLink', time: DateTime.now());
 
     if (mosqueConfig?.adhanVoice?.isNotEmpty ?? false) {
-      baseLink = "$kStaticFilesUrl/mp3/${mosqueConfig!.adhanVoice!}.mp3";
+      baseLink = "$kStaticFilesUrl/audio/${mosqueConfig!.adhanVoice!}.mp3";
+      logger.d('[StaticFileURL] PrayerScheduleService: Using custom adhan voice: $baseLink', time: DateTime.now());
     }
 
     if (useFajrAdhan && !baseLink.contains('bip')) {
       baseLink = baseLink.replaceAll('.mp3', '-fajr.mp3');
+      logger.d('[StaticFileURL] PrayerScheduleService: Modified for Fajr: $baseLink', time: DateTime.now());
     }
 
     return baseLink;

--- a/lib/src/services/notification/prayer_schedule_service.dart
+++ b/lib/src/services/notification/prayer_schedule_service.dart
@@ -371,7 +371,8 @@ class PrayerScheduleService {
 
   static String getAdhanLink(MosqueConfig? mosqueConfig, {bool useFajrAdhan = false}) {
     String baseLink = "$kStaticFilesUrl/audio/adhan-afassy.mp3";
-    logger.d('[StaticFileURL] PrayerScheduleService: Base adhan link using static URL: $baseLink', time: DateTime.now());
+    logger.d('[StaticFileURL] PrayerScheduleService: Base adhan link using static URL: $baseLink',
+        time: DateTime.now());
 
     if (mosqueConfig?.adhanVoice?.isNotEmpty ?? false) {
       baseLink = "$kStaticFilesUrl/audio/${mosqueConfig!.adhanVoice!}.mp3";


### PR DESCRIPTION
📝 Summary

This PR fixes #1704 

Description

This PR updates the static files URL from https://mawaqit.net/static to the new CDN path https://cdn.mawaqit.net for both production and staging environments.
It also updates the audio asset paths from mp3/ to audio/ across the app to align with the updated file structure on the CDN.

Additionally, minor cleanup was done:
	•	Removed redundant logging inside AudioManager
	•	Added debug logs in PrayerScheduleService to trace the selected audio URLs

Tests

🧪 Use case 1

💬 Description: Verify correct audio files are being used and played:
	•	Bip sound
	•	Adhan voices (default and custom)
	•	Duaa after adhan
	•	Special handling for Fajr adhan

📷 Screenshots or GIFs (if applicable):
N/A

Checklist:
- [x]	Coding Standards: I have reviewed my code to ensure it follows the project’s coding standards
- [x] Testing: I have tested the changes and they work as expected.
- [x] Merge Conflicts: I have resolved any merge conflicts with the latest main/development branch.
- [x]  Branch Status: The branch is up-to-date with the target branch (main/development).