### PR TITLE
fix: hadith content displaying in Arabic regardless of selected language

### DIFF
--- a/lib/i18n/AppLanguage.dart
+++ b/lib/i18n/AppLanguage.dart
@@ -125,13 +125,17 @@ class AppLanguage extends ChangeNotifier {
   Future<String> getHadithLanguage(MosqueManager mosqueManager) async {
     final SharedPreferences prefs = await SharedPreferences.getInstance();
     final String? hadithLanguage = prefs.getString(RandomHadithConstant.kHadithLanguage);
-    if (hadithLanguage != null) {
+    if (hadithLanguage != null && hadithLanguage.isNotEmpty) {
       _hadithLanguage = hadithLanguage;
       notifyListeners();
       return hadithLanguage;
     } else {
-      _hadithLanguage = mosqueManager.mosqueConfig!.hadithLang ?? "ar";
-      return mosqueManager.mosqueConfig!.hadithLang ?? "ar";
+      final fallbackLang = mosqueManager.mosqueConfig?.hadithLang ?? "ar";
+      _hadithLanguage = fallbackLang;
+      // Save the fallback language to shared preferences so it persists
+      await prefs.setString(RandomHadithConstant.kHadithLanguage, fallbackLang);
+      notifyListeners();
+      return fallbackLang;
     }
   }
 

--- a/lib/src/state_management/random_hadith/random_hadith_notifier.dart
+++ b/lib/src/state_management/random_hadith/random_hadith_notifier.dart
@@ -45,10 +45,22 @@ class RandomHadithNotifier extends AsyncNotifier<RandomHadithState> {
 
   Future<void> ensureHadithLanguage() async {
     final prefs = await SharedPreferences.getInstance();
-    final language = prefs.getString(RandomHadithConstant.kHadithLanguage) ?? AppLanguage().hadithLanguage;
+    final storedLanguage = prefs.getString(RandomHadithConstant.kHadithLanguage);
+
+    // Get effective language - prioritize stored preference, then app language, default to Arabic
+    final language = (storedLanguage != null && storedLanguage.isNotEmpty)
+        ? storedLanguage
+        : (AppLanguage().hadithLanguage.isNotEmpty ? AppLanguage().hadithLanguage : 'ar');
+
+    if (storedLanguage == null || storedLanguage.isEmpty) {
+      await prefs.setString(RandomHadithConstant.kHadithLanguage, language);
+    }
+
     // Ensure hadiths are cached during initialization
     final randomHadithRepository = await ref.read(randomHadithRepositoryProvider.future);
     await randomHadithRepository.ensureHadithsAreCached(language);
+
+    await getRandomHadith(language: language);
   }
 }
 


### PR DESCRIPTION
📝 **Summary**
---
**This PR fixes** #1739 

**Description**
---
Some users reported that the Hadith content was always displaying in Arabic, regardless of the selected language in the app settings. After investigation, we found that the issue was related to unnecessary Arabic language fallback logic in the data layer that was overriding the user's language preferences.

This PR removes redundant Arabic fallback mechanisms from `random_hadith_impl.dart` since the language selection is already properly handled at a higher level in both `AppLanguage` and `RandomHadithNotifier` classes.

**Changes made:**
1. Removed unnecessary Arabic fallback logic in `_handleOfflineMode` method for both single and two-language cases
2. Removed redundant Arabic hadith caching in `ensureHadithsAreCached` method
3. Relies on existing language fallback mechanisms in `AppLanguage.getHadithLanguage()` and `RandomHadithNotifier.ensureHadithLanguage()`

**Tests**
---
🧪 **Use case 1: Language Persistence**
---
💬 **Description:**
1. Set app language to non-Arabic (e.g., English)
2. Verify Hadith displays in English
3. Close and reopen app
5. Verify Hadith remains in English
6. Go offline
7. Verify Hadith still displays in English from cache

🧪 **Use case 2: First Launch Default**
---
💬 **Description:**
1. Fresh install of app
2. Verify Hadith displays in mosque's configured language
3. If no mosque config, verifies it falls back to Arabic

🧪 **Use case 3: Language Switching**
---
💬 **Description:**
1. Switch between different languages
2. Verify Hadith content updates accordingly
3. Verify no unexpected fallback to Arabic occurs

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).