### PR TITLE
fix: finish button at the end of choose between mosque and home

### DIFF
--- a/lib/src/pages/onBoarding/widgets/onboarding_bottom_navigation_bar.dart
+++ b/lib/src/pages/onBoarding/widgets/onboarding_bottom_navigation_bar.dart
@@ -27,17 +27,8 @@ class OnboardingBottomNavigationBar extends ConsumerWidget {
 
     return state.when(
       data: (data) {
-        final screenType = data.screenFlow[data.currentScreen];
-        final isMosqueSearch = switch (screenType) {
-          OnboardingScreenType.mosqueId || OnboardingScreenType.mosqueName => true,
-          OnboardingScreenType.chromecastMosqueId || OnboardingScreenType.chromecastMosqueName => true,
-          _ => false
-        };
         final isMosqueSearchSelected = ref.watch(mosqueManagerProvider).fold(() => false, (t) => true);
-
-        // Check if current screen is country or timezone selection
-        final isCountryOrTimezoneScreen =
-            screenType == OnboardingScreenType.countrySelection || screenType == OnboardingScreenType.timezoneSelection;
+        final shouldShowFinish = data.shouldShowFinishButton(isMosqueSearchSelected);
         return Container(
           padding: const EdgeInsets.only(left: 30, right: 30, bottom: 20),
           child: Row(
@@ -91,7 +82,7 @@ class OnboardingBottomNavigationBar extends ConsumerWidget {
                       // Only show the button when it's either:
                       // 1. Not a mosque search screen, OR
                       // 2. A mosque search screen WITH a mosque selected
-                      if (isCountryOrTimezoneScreen && onSkipPressed != null)
+                      if (data.canSkipCurrentScreen && onSkipPressed != null)
                         MawaqitIconButton(
                           focusNode: nextButtonFocusNode ?? FocusNode(),
                           icon: Icons.navigate_next,
@@ -99,11 +90,11 @@ class OnboardingBottomNavigationBar extends ConsumerWidget {
                           onPressed: onSkipPressed,
                           isAutoFocus: true,
                         )
-                      else if (!isMosqueSearch || (isMosqueSearch && isMosqueSearchSelected))
+                      else if (!data.isMosqueSearchScreen || (data.isMosqueSearchScreen && isMosqueSearchSelected))
                         MawaqitIconButton(
                           focusNode: nextButtonFocusNode ?? FocusNode(),
                           icon: data.isLastItem ? Icons.check : Icons.arrow_forward_rounded,
-                          label: data.isLastItem ? S.of(context).finish : S.of(context).next,
+                          label: shouldShowFinish ? S.of(context).finish : S.of(context).next,
                           onPressed: onNextPressed,
                         )
                       else

--- a/lib/src/state_management/on_boarding/v2/onboarding_navigation_state.dart
+++ b/lib/src/state_management/on_boarding/v2/onboarding_navigation_state.dart
@@ -42,23 +42,24 @@ class OnboardingNavigationState {
 
   /// Computed properties for UI logic
   bool get isMosqueSearchScreen => switch (currentScreenType) {
-    OnboardingScreenType.mosqueId || OnboardingScreenType.mosqueName => true,
-    OnboardingScreenType.chromecastMosqueId || OnboardingScreenType.chromecastMosqueName => true,
-    _ => false
-  };
+        OnboardingScreenType.mosqueId || OnboardingScreenType.mosqueName => true,
+        OnboardingScreenType.chromecastMosqueId || OnboardingScreenType.chromecastMosqueName => true,
+        _ => false
+      };
 
   bool get canSkipCurrentScreen => switch (currentScreenType) {
-    OnboardingScreenType.countrySelection || OnboardingScreenType.timezoneSelection => true,
-    _ => false
-  };
+        OnboardingScreenType.countrySelection || OnboardingScreenType.timezoneSelection => true,
+        _ => false
+      };
 
   bool shouldShowFinishButton(bool isMosqueSelected) {
     final isAtLastScreen = currentScreen == screenFlow.length - 1;
-    
+
     return switch (currentScreenType) {
       OnboardingScreenType.announcement when isAtLastScreen => true,
-      OnboardingScreenType.mosqueId || OnboardingScreenType.chromecastMosqueId 
-        when isMosqueSelected && isAtLastScreen => true,
+      OnboardingScreenType.mosqueId ||
+      OnboardingScreenType.chromecastMosqueId when isMosqueSelected && isAtLastScreen =>
+        true,
       _ => false,
     };
   }

--- a/lib/src/state_management/on_boarding/v2/onboarding_navigation_state.dart
+++ b/lib/src/state_management/on_boarding/v2/onboarding_navigation_state.dart
@@ -38,6 +38,31 @@ class OnboardingNavigationState {
 
   int get totalScreens => screenFlow.length;
 
+  OnboardingScreenType get currentScreenType => screenFlow[currentScreen];
+
+  /// Computed properties for UI logic
+  bool get isMosqueSearchScreen => switch (currentScreenType) {
+    OnboardingScreenType.mosqueId || OnboardingScreenType.mosqueName => true,
+    OnboardingScreenType.chromecastMosqueId || OnboardingScreenType.chromecastMosqueName => true,
+    _ => false
+  };
+
+  bool get canSkipCurrentScreen => switch (currentScreenType) {
+    OnboardingScreenType.countrySelection || OnboardingScreenType.timezoneSelection => true,
+    _ => false
+  };
+
+  bool shouldShowFinishButton(bool isMosqueSelected) {
+    final isAtLastScreen = currentScreen == screenFlow.length - 1;
+    
+    return switch (currentScreenType) {
+      OnboardingScreenType.announcement when isAtLastScreen => true,
+      OnboardingScreenType.mosqueId || OnboardingScreenType.chromecastMosqueId 
+        when isMosqueSelected && isAtLastScreen => true,
+      _ => false,
+    };
+  }
+
   OnboardingNavigationState copyWith({
     int? currentScreen,
     bool? enablePreviousButton,


### PR DESCRIPTION
solves this #1798

## Problem
The onboarding screen showing "Do you know your installation ID or your Mosque ID?" was displaying a "Finish" button instead of "Next", causing user confusion.

## Solution
- Fixed button logic to only show "Finish" when actually at the last screen of the flow
- **Mosque flow**: Shows "Next" → "Next" → "Finish" (on announcement screen)
- **Home flow**: Shows "Next" → "Finish" (on final mosque ID screen)
- Refactored business logic into computed properties for cleaner architecture

## Changes
- Updated `OnboardingNavigationState` with computed properties
- Simplified UI logic in `OnboardingBottomNavigationBar`
- Removed redundant methods from notifier

![output 2](https://github.com/user-attachments/assets/014c99dc-6932-4489-880a-d3c9f68c7a06)
