### PR TITLE
fix: Improve time display alignment and sizing for Arabic period indicators

### DIFF
--- a/lib/src/pages/home/widgets/footer.dart
+++ b/lib/src/pages/home/widgets/footer.dart
@@ -32,7 +32,9 @@ class Footer extends StatelessWidget {
       flex: showMosqueInfo ? 2 : 1,
       child: Row(
         children: [
-          _buildQrCodeSection(mosque, textDirection),
+          Flexible(
+            child: _buildQrCodeSection(mosque, textDirection),
+          ),
         ],
       ),
     );

--- a/lib/src/pages/home/widgets/salah_items/responsive_mini_salah_bar_widget.dart
+++ b/lib/src/pages/home/widgets/salah_items/responsive_mini_salah_bar_widget.dart
@@ -49,22 +49,26 @@ class ResponsiveMiniSalahBarWidget extends StatelessOrientationWidget {
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
           if (turkishImask != null)
-            SalahItemWidget(removeBackground: true, time: turkishImask, isIqamaMoreImportant: isIqamaMoreImportant)
-                .animate()
-                .fadeIn(duration: _duration)
-                .slideY(begin: 1, duration: _duration, curve: Curves.easeOut)
-                .addRepaintBoundary(),
+            Flexible(
+              child: SalahItemWidget(removeBackground: true, time: turkishImask, isIqamaMoreImportant: isIqamaMoreImportant)
+                  .animate()
+                  .fadeIn(duration: _duration)
+                  .slideY(begin: 1, duration: _duration, curve: Curves.easeOut)
+                  .addRepaintBoundary(),
+            ),
           for (var i = 0; i < 5; i++)
-            SalahItemWidget(
-                    withDivider: false,
-                    iqama: isIqamaMoreImportant ? iqamas[i] : null,
-                    time: todayTimes[i],
-                    active: i == 1 ? nextActiveIqama == i && !duhrHighlightDisable : nextActiveIqama == i,
-                    isIqamaMoreImportant: isIqamaMoreImportant)
-                .animate(delay: _step * (i + 1))
-                .fadeIn(duration: _duration)
-                .slideY(begin: 1, duration: _duration, curve: Curves.easeOut)
-                .addRepaintBoundary(),
+            Flexible(
+              child: SalahItemWidget(
+                      withDivider: false,
+                      iqama: isIqamaMoreImportant ? iqamas[i] : null,
+                      time: todayTimes[i],
+                      active: i == 1 ? nextActiveIqama == i && !duhrHighlightDisable : nextActiveIqama == i,
+                      isIqamaMoreImportant: isIqamaMoreImportant)
+                  .animate(delay: _step * (i + 1))
+                  .fadeIn(duration: _duration)
+                  .slideY(begin: 1, duration: _duration, curve: Curves.easeOut)
+                  .addRepaintBoundary(),
+            ),
         ],
       ),
     );

--- a/lib/src/pages/home/widgets/salah_items/responsive_mini_salah_bar_widget.dart
+++ b/lib/src/pages/home/widgets/salah_items/responsive_mini_salah_bar_widget.dart
@@ -50,7 +50,8 @@ class ResponsiveMiniSalahBarWidget extends StatelessOrientationWidget {
         children: [
           if (turkishImask != null)
             Flexible(
-              child: SalahItemWidget(removeBackground: true, time: turkishImask, isIqamaMoreImportant: isIqamaMoreImportant)
+              child: SalahItemWidget(
+                      removeBackground: true, time: turkishImask, isIqamaMoreImportant: isIqamaMoreImportant)
                   .animate()
                   .fadeIn(duration: _duration)
                   .slideY(begin: 1, duration: _duration, curve: Curves.easeOut)

--- a/lib/src/widgets/TimePeriodWidget.dart
+++ b/lib/src/widgets/TimePeriodWidget.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart' hide TextDirection;
-import 'package:mawaqit/i18n/AppLanguage.dart';
-import 'package:provider/provider.dart';
 import 'package:sizer/sizer.dart';
 
 class TimePeriodWidget extends StatelessWidget {
@@ -16,8 +14,6 @@ class TimePeriodWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final appLanguage = context.read<AppLanguage>();
-    final isArabic = appLanguage.isArabic();
     final value = DateFormat(
       "a",
       Localizations.localeOf(context).languageCode,
@@ -25,7 +21,7 @@ class TimePeriodWidget extends StatelessWidget {
 
     final defaultStyle = DefaultTextStyle.of(context).style;
     final textStyle = (style ?? defaultStyle).copyWith(
-      height: 3,
+      height: 1,
     );
 
     return ConstrainedBox(
@@ -34,7 +30,7 @@ class TimePeriodWidget extends StatelessWidget {
         fit: BoxFit.scaleDown,
         child: Text(
           value,
-          maxLines: value.length,
+          maxLines: 1,
           textAlign: TextAlign.center,
           style: textStyle,
         ),

--- a/lib/src/widgets/time_widget.dart
+++ b/lib/src/widgets/time_widget.dart
@@ -1,9 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:mawaqit/i18n/AppLanguage.dart';
 import 'package:mawaqit/src/helpers/RelativeSizes.dart';
 import 'package:mawaqit/src/helpers/time_utils.dart';
 import 'package:mawaqit/src/widgets/TimePeriodWidget.dart';
-import 'package:provider/provider.dart';
 
 /// this widget should be used the show times in the app
 class TimeWidget extends StatelessWidget {
@@ -47,7 +45,6 @@ class TimeWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isArabicLang = context.read<AppLanguage>().isArabic();
     if (time == null) return Text(fallbackString ?? '', style: style);
 
     if (show24hFormat) {
@@ -59,7 +56,7 @@ class TimeWidget extends StatelessWidget {
 
     return Row(
       mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.end,
+      crossAxisAlignment: CrossAxisAlignment.center,
       children: [
         Text(
           "${time!.hourOfPeriod.toString().padLeft(2, '0')}:${time!.minute.toString().padLeft(2, '0')}",


### PR DESCRIPTION
Issue it closes #1812 

## Problem
The Arabic period indicators (ص/م) and English AM/PM indicators were displaying incorrectly in prayer time widgets:
- **Oversized text**: Arabic characters appeared much larger than time numbers
- **Subscript alignment**: Period indicators were positioned below the baseline instead of inline
- **Poor readability**: Time displays had excessive line height causing layout issues

## Solution
Fixed the `TimePeriodWidget` and `TimeWidget` components:

### TimePeriodWidget Changes:
- **Reduced line height**: Changed from `height: 3` to `height: 1` for proper text scaling
- **Fixed maxLines logic**: Changed from `maxLines: value.length` to `maxLines: 1` for consistent behavior
- **Improved text alignment**: Ensured period indicators display inline with time numbers

### TimeWidget Changes:
- **Fixed cross-axis alignment**: Changed from `CrossAxisAlignment.end` to `CrossAxisAlignment.center`
- **Cleanup**: Removed unused imports and variables

## Before & After
**Before**: Arabic ص/م characters appeared oversized and subscripted
<img width="1640" height="1004" alt="Image" src="https://github.com/user-attachments/assets/8ed6ee9c-eb8a-4d8e-a41a-53cd1efe75f4" />

**After**: Period indicators now display inline at proper size with time numbers
![After - Properly sized and aligned](https://github.com/user-attachments/assets/a49d0d8d-227d-4031-81e9-b40eaf71186f)
![Before - Oversized Arabic characters](https://github.com/user-attachments/assets/a3dbad9d-acd8-4aaf-97b1-ba23d227f706)

## Testing
- Arabic period indicators (ص/م) display at correct size
- English AM/PM indicators align properly
- Time displays maintain consistent layout across different screen sizes
- No impact on 24-hour format displays