### PR TITLE
feat: display mosque website URL on TV screen footer

### DIFF
--- a/lib/src/pages/home/widgets/MosqueInformationWidget.dart
+++ b/lib/src/pages/home/widgets/MosqueInformationWidget.dart
@@ -1,7 +1,9 @@
+import 'dart:developer';
 import 'package:flutter/material.dart';
 import 'package:mawaqit/src/helpers/RelativeSizes.dart';
 import 'package:mawaqit/src/services/mosque_manager.dart';
 import 'package:provider/provider.dart';
+import 'package:sizer/sizer.dart';
 
 import '../../../helpers/mawaqit_icons_icons.dart';
 
@@ -13,22 +15,58 @@ class MosqueInformationWidget extends StatelessWidget {
     final mosque = context.read<MosqueManager>().mosque;
     String phoneNumber = "${mosque?.phone != null ? mosque!.phone : ""} ";
     String association = "${mosque?.association != null ? mosque?.association : ""} ";
-    // String bank = "${mosque?.} ";
+    String website = "${mosque?.site != null && mosque!.site!.isNotEmpty ? mosque.site : ""} ";
+
+    log('Mosque phone: ${mosque?.phone}');
+    log('Mosque website: ${mosque?.site}');
 
     return Padding(
-      padding: EdgeInsets.symmetric(vertical: 1.5.vh),
+      padding: EdgeInsets.symmetric(vertical: 2.5.vh, horizontal: 2.w),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
           Text(
             association,
-            style: TextStyle(color: Colors.white),
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: 10.sp,
+              fontWeight: FontWeight.w600,
+            ),
           ),
-          mosque!.phone != null ? Icon(Icons.phone_iphone) : SizedBox(),
-          Text(
-            phoneNumber,
-            style: TextStyle(color: Colors.white),
-          ),
+          if (mosque!.phone != null) ...[
+            SizedBox(width: 2.w),
+            Icon(
+              Icons.phone_iphone,
+              color: Colors.white,
+              size: 12.sp,
+            ),
+            SizedBox(width: 1.w),
+            Text(
+              phoneNumber,
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 10.sp,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+          if (mosque.site != null && mosque.site!.isNotEmpty) ...[
+            SizedBox(width: 2.w),
+            Icon(
+              Icons.language,
+              color: Colors.white,
+              size: 12.sp,
+            ),
+            SizedBox(width: 1.w),
+            Text(
+              website,
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 10.sp,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
         ],
       ),
     );


### PR DESCRIPTION
# 📝 **Summary**

---

**This PR fixes** #1225

## **Description**

---

Implements the display of mosque website URL on the TV screen footer as requested in issue #1225. The feature adds website information alongside the existing association name and phone number display.

### Changes Made:
- Added website URL display in `MosqueInformationWidget` 
- Implemented responsive sizing using scalable pixels (10.sp for text, 12.sp for icons)
- Added conditional rendering to only show phone/website when data is available
- Used `Icons.language` for website icon (consistent with app's existing usage)
- Added proper spacing and padding for better TV visibility
- Included debugging logs for API data verification

### Technical Details:
- Uses existing `mosque.site` field from `/3.0/mosque/{id}/info` API endpoint
- Maintains backward compatibility - displays gracefully when fields are null
- Follows existing code patterns and styling conventions

## **Tests**

---

### 🧪 **Use case 1**

---

**💬 Description:**

Testing mosque information display with website data:
- Verify website URL appears when `mosque.site` field contains data
- Confirm proper spacing and icon display
- Ensure responsive behavior on different TV screen sizes
- Validate that empty/null website fields don't break layout

### 📷 **Screenshots or GIFs (if applicable):**

<img width="970" height="557" alt="image" src="https://github.com/user-attachments/assets/ed299dd8-94ce-4bf2-8cdd-240c311b17d1" />


## **Checklist:**

---

- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).