### PR TITLE
fix: Put Hafs in first position in Quran selection dialog

### DIFF
--- a/lib/src/pages/quran/widget/download_quran_popup.dart
+++ b/lib/src/pages/quran/widget/download_quran_popup.dart
@@ -197,26 +197,24 @@ class _DownloadQuranDialogState extends ConsumerState<DownloadQuranDialog> {
   }
 
   Widget _buildChooseDownloadMoshaf(BuildContext context) {
-    return Focus(
-      focusNode: _dialogFocusNode,
-      child: AlertDialog(
+    return AlertDialog(
         title: Text(S.of(context).chooseQuranType),
         content: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
             _buildMoshafTypeRadio(
               context,
-              title: S.of(context).warsh,
-              value: MoshafType.warsh,
-              setState: setState,
-              autofocus: selectedMoshafType == MoshafType.warsh,
-            ),
-            _buildMoshafTypeRadio(
-              context,
               title: S.of(context).hafs,
               value: MoshafType.hafs,
               setState: setState,
               autofocus: selectedMoshafType == MoshafType.hafs,
+            ),
+            _buildMoshafTypeRadio(
+              context,
+              title: S.of(context).warsh,
+              value: MoshafType.warsh,
+              setState: setState,
+              autofocus: selectedMoshafType == MoshafType.warsh,
             ),
           ],
         ),
@@ -247,8 +245,7 @@ class _DownloadQuranDialogState extends ConsumerState<DownloadQuranDialog> {
             child: Text(S.of(context).download),
           ),
         ],
-      ),
-    );
+      );
   }
 
   Widget _buildMoshafTypeRadio(
@@ -258,17 +255,31 @@ class _DownloadQuranDialogState extends ConsumerState<DownloadQuranDialog> {
     required void Function(VoidCallback fn) setState,
     bool autofocus = false,
   }) {
-    return RadioListTile<MoshafType>(
-      title: Text(title),
-      value: value,
+    return InkWell(
       autofocus: autofocus,
-      groupValue: selectedMoshafType,
-      onChanged: (MoshafType? selected) {
+      onTap: () {
         setState(() {
-          selectedMoshafType = selected!;
+          selectedMoshafType = value;
         });
-        ref.read(moshafTypeNotifierProvider.notifier).selectMoshafType(selectedMoshafType);
+        ref.read(moshafTypeNotifierProvider.notifier).selectMoshafType(value);
       },
+      child: RadioListTile<MoshafType>(
+        title: Text(
+          title,
+          style: TextStyle(
+            color: selectedMoshafType == value ? Colors.white : null,
+          ),
+        ),
+        value: value,
+        selected: selectedMoshafType == value,
+        groupValue: selectedMoshafType,
+        onChanged: (MoshafType? selected) {
+          setState(() {
+            selectedMoshafType = selected!;
+          });
+          ref.read(moshafTypeNotifierProvider.notifier).selectMoshafType(selectedMoshafType);
+        },
+      ),
     );
   }
 

--- a/lib/src/pages/quran/widget/download_quran_popup.dart
+++ b/lib/src/pages/quran/widget/download_quran_popup.dart
@@ -198,54 +198,54 @@ class _DownloadQuranDialogState extends ConsumerState<DownloadQuranDialog> {
 
   Widget _buildChooseDownloadMoshaf(BuildContext context) {
     return AlertDialog(
-        title: Text(S.of(context).chooseQuranType),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            _buildMoshafTypeRadio(
-              context,
-              title: S.of(context).hafs,
-              value: MoshafType.hafs,
-              setState: setState,
-              autofocus: selectedMoshafType == MoshafType.hafs,
-            ),
-            _buildMoshafTypeRadio(
-              context,
-              title: S.of(context).warsh,
-              value: MoshafType.warsh,
-              setState: setState,
-              autofocus: selectedMoshafType == MoshafType.warsh,
-            ),
-          ],
-        ),
-        actions: [
-          TextButton(
-            onPressed: () {
-              final moshafType = ref.watch(moshafTypeNotifierProvider);
-              moshafType.when(
-                data: (data) {
-                  if (data.isFirstTime) {
-                    Navigator.pushNamedAndRemoveUntil(context, Routes.quranModeSelection, (route) => route.isFirst);
-                  } else {
-                    Navigator.pop(context);
-                  }
-                },
-                error: (_, __) {},
-                loading: () {},
-              );
-            },
-            child: Text(S.of(context).cancel),
+      title: Text(S.of(context).chooseQuranType),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _buildMoshafTypeRadio(
+            context,
+            title: S.of(context).hafs,
+            value: MoshafType.hafs,
+            setState: setState,
+            autofocus: selectedMoshafType == MoshafType.hafs,
           ),
-          TextButton(
-            autofocus: true,
-            onPressed: () async {
-              Navigator.pop(context);
-              await ref.read(downloadQuranNotifierProvider.notifier).downloadQuran(selectedMoshafType);
-            },
-            child: Text(S.of(context).download),
+          _buildMoshafTypeRadio(
+            context,
+            title: S.of(context).warsh,
+            value: MoshafType.warsh,
+            setState: setState,
+            autofocus: selectedMoshafType == MoshafType.warsh,
           ),
         ],
-      );
+      ),
+      actions: [
+        TextButton(
+          onPressed: () {
+            final moshafType = ref.watch(moshafTypeNotifierProvider);
+            moshafType.when(
+              data: (data) {
+                if (data.isFirstTime) {
+                  Navigator.pushNamedAndRemoveUntil(context, Routes.quranModeSelection, (route) => route.isFirst);
+                } else {
+                  Navigator.pop(context);
+                }
+              },
+              error: (_, __) {},
+              loading: () {},
+            );
+          },
+          child: Text(S.of(context).cancel),
+        ),
+        TextButton(
+          autofocus: true,
+          onPressed: () async {
+            Navigator.pop(context);
+            await ref.read(downloadQuranNotifierProvider.notifier).downloadQuran(selectedMoshafType);
+          },
+          child: Text(S.of(context).download),
+        ),
+      ],
+    );
   }
 
   Widget _buildMoshafTypeRadio(

--- a/lib/src/pages/quran/widget/download_quran_popup.dart
+++ b/lib/src/pages/quran/widget/download_quran_popup.dart
@@ -255,31 +255,22 @@ class _DownloadQuranDialogState extends ConsumerState<DownloadQuranDialog> {
     required void Function(VoidCallback fn) setState,
     bool autofocus = false,
   }) {
-    return InkWell(
-      autofocus: autofocus,
-      onTap: () {
-        setState(() {
-          selectedMoshafType = value;
-        });
-        ref.read(moshafTypeNotifierProvider.notifier).selectMoshafType(value);
-      },
-      child: RadioListTile<MoshafType>(
-        title: Text(
-          title,
-          style: TextStyle(
-            color: selectedMoshafType == value ? Colors.white : null,
-          ),
+    return RadioListTile<MoshafType>(
+      title: Text(
+        title,
+        style: TextStyle(
+          color: selectedMoshafType == value ? Colors.white : null,
         ),
-        value: value,
-        selected: selectedMoshafType == value,
-        groupValue: selectedMoshafType,
-        onChanged: (MoshafType? selected) {
-          setState(() {
-            selectedMoshafType = selected!;
-          });
-          ref.read(moshafTypeNotifierProvider.notifier).selectMoshafType(selectedMoshafType);
-        },
       ),
+      value: value,
+      selected: selectedMoshafType == value,
+      groupValue: selectedMoshafType,
+      onChanged: (MoshafType? selected) {
+        setState(() {
+          selectedMoshafType = selected!;
+        });
+        ref.read(moshafTypeNotifierProvider.notifier).selectMoshafType(selectedMoshafType);
+      },
     );
   }
 


### PR DESCRIPTION
📝 **Summary**
---
**This PR fixes** #1851

**Description**
---
This PR addresses the requirement to display Hafs as the first option in the Quran selection dialog. Previously, Warsh appeared first and Hafs second. Now Hafs is displayed at the top and is selected by default.

**Changes made:**
- Reordered radio buttons in `download_quran_popup.dart` to show Hafs first
- Hafs now appears at the top of the selection dialog
- Maintained default selection as Hafs (which was already the case)

**Tests**
---
🧪 **Use case 1: Quran selection dialog order**
---
💬 **Description:** When opening the Quran download dialog, Hafs should appear as the first option

**Expected behavior:**
- Hafs appears at the top of the list
- Hafs is selected by default (radio button filled)
- Warsh appears as the second option
- Navigation with TV remote works correctly between options

📷 **Screenshots:**

Before:
- Warsh (first position)
- Hafs (second position) 

<img width="964" height="543" alt="image" src="https://github.com/user-attachments/assets/3b79aa1f-7756-4e5f-b5b5-0dfcc11fc471" />

After:
- Hafs (first position) ✓ Selected
- Warsh (second position)

<img width="964" height="541" alt="image" src="https://github.com/user-attachments/assets/d13f54e8-4e5c-4df1-ab00-3c9d8adcb3c1" />

<img width="957" height="551" alt="image" src="https://github.com/user-attachments/assets/4b3538b2-75dd-4e84-b797-44ef32604388" />

**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (release-1.24).