### PR TITLE
fix: optimize iqama countdown screen spacing and layout

### DIFF
--- a/lib/src/pages/home/sub_screens/IqamaaCountDownSubScreen.dart
+++ b/lib/src/pages/home/sub_screens/IqamaaCountDownSubScreen.dart
@@ -115,14 +115,14 @@ class _IqamaaCountDownSubScreenState extends State<IqamaaCountDownSubScreen> {
 
           // Clock Widget from Main Screen (compact version)
           Container(
-            height: 25.vh, // Slightly increased to prevent overflow
+            height: 20.vh, // Balanced reduction to prevent overflow
             alignment: Alignment.center,
             child: ClipRect(
               child: FittedBox(
                 fit: BoxFit.contain,
                 child: SizedBox(
                   width: 60.vw, // Give explicit width to child
-                  height: 35.vh, // Increased height to prevent internal overflow
+                  height: 28.vh, // Adjusted to prevent overflow
                   child: HomeTimeWidget(showSalahIn: false, showOuterBackground: false),
                 ),
               ),
@@ -188,8 +188,10 @@ class _IqamaaCountDownSubScreenState extends State<IqamaaCountDownSubScreen> {
             ),
           ),
 
-          // Bottom prayer times bar
-          mosqueManager.times!.isTurki ? ResponsiveMiniSalahBarTurkishWidget() : ResponsiveMiniSalahBarWidget(),
+          // Bottom prayer times bar with compact spacing for iqama countdown
+          mosqueManager.times!.isTurki
+              ? ResponsiveMiniSalahBarTurkishWidget(useCompactLayout: true)
+              : ResponsiveMiniSalahBarWidget(useCompactLayout: true),
         ],
       ),
     );

--- a/lib/src/pages/home/widgets/salah_items/responsive_mini_salah_bar_turkish_widget.dart
+++ b/lib/src/pages/home/widgets/salah_items/responsive_mini_salah_bar_turkish_widget.dart
@@ -18,11 +18,26 @@ const _duration = Duration(milliseconds: 300);
 
 /// used on secondary screens to show salah bar in a smaller size
 class ResponsiveMiniSalahBarTurkishWidget extends StatelessOrientationWidget {
-  const ResponsiveMiniSalahBarTurkishWidget({super.key, this.activeItem});
+  const ResponsiveMiniSalahBarTurkishWidget({
+    super.key,
+    this.activeItem,
+    this.horizontalPadding,
+    this.itemPadding,
+    this.useCompactLayout = false,
+  });
 
   /// used to force salah item to be active
   /// if null, will be calculated based on next iqama
   final int? activeItem;
+
+  /// Custom horizontal padding for the entire bar
+  final double? horizontalPadding;
+
+  /// Custom padding between items
+  final double? itemPadding;
+
+  /// Use compact layout with reduced spacing
+  final bool useCompactLayout;
 
   @override
   Widget buildLandscape(BuildContext context) {
@@ -37,9 +52,9 @@ class ResponsiveMiniSalahBarTurkishWidget extends StatelessOrientationWidget {
 
     final nextActiveSalah = mosqueManager.nextSalahIndex();
     return Padding(
-      padding: EdgeInsets.symmetric(horizontal: 3.vw),
+      padding: EdgeInsets.symmetric(horizontal: horizontalPadding ?? (useCompactLayout ? 1.5.vw : 3.vw)),
       child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        mainAxisAlignment: useCompactLayout ? MainAxisAlignment.spaceEvenly : MainAxisAlignment.spaceBetween,
         children: [
           SalahItemWidget(
             time: times[0],
@@ -77,7 +92,7 @@ class ResponsiveMiniSalahBarTurkishWidget extends StatelessOrientationWidget {
         ]
             .mapIndexed((i, e) => Expanded(
                     child: Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 1.vw),
+                  padding: EdgeInsets.symmetric(horizontal: itemPadding ?? (useCompactLayout ? 0.5.vw : 1.vw)),
                   child: e.animate(delay: Duration(milliseconds: 100 * i)).slideY(begin: 1).fade(),
                 )))
             .toList(),
@@ -108,7 +123,7 @@ class ResponsiveMiniSalahBarTurkishWidget extends StatelessOrientationWidget {
       required bool active,
     }) {
       return Padding(
-        padding: EdgeInsets.symmetric(horizontal: 1.vw),
+        padding: EdgeInsets.symmetric(horizontal: itemPadding ?? (useCompactLayout ? 0.5.vw : 1.vw)),
         child: SizedBox(
           width: 22.vw,
           height: 12.vh,

--- a/lib/src/pages/home/widgets/salah_items/responsive_mini_salah_bar_widget.dart
+++ b/lib/src/pages/home/widgets/salah_items/responsive_mini_salah_bar_widget.dart
@@ -18,11 +18,26 @@ const _duration = Duration(milliseconds: 300);
 
 /// used on secondary screens to show salah bar in a smaller size
 class ResponsiveMiniSalahBarWidget extends StatelessOrientationWidget {
-  const ResponsiveMiniSalahBarWidget({super.key, this.activeItem});
+  const ResponsiveMiniSalahBarWidget({
+    super.key,
+    this.activeItem,
+    this.horizontalPadding,
+    this.itemSpacing,
+    this.useCompactLayout = false,
+  });
 
   /// used to force salah item to be active
   /// if null, will be calculated based on next iqama
   final int? activeItem;
+
+  /// Custom horizontal padding for the entire bar
+  final double? horizontalPadding;
+
+  /// Custom spacing between items (portrait mode)
+  final double? itemSpacing;
+
+  /// Use compact layout with reduced spacing
+  final bool useCompactLayout;
 
   @override
   Widget buildLandscape(BuildContext context) {
@@ -44,9 +59,9 @@ class ResponsiveMiniSalahBarWidget extends StatelessOrientationWidget {
     bool duhrHighlightDisable = mosqueProvider.mosqueDate().weekday == DateTime.friday && mosqueProvider.typeIsMosque;
 
     return Padding(
-      padding: EdgeInsets.symmetric(horizontal: 3.vw),
+      padding: EdgeInsets.symmetric(horizontal: horizontalPadding ?? (useCompactLayout ? 1.5.vw : 3.vw)),
       child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        mainAxisAlignment: useCompactLayout ? MainAxisAlignment.spaceEvenly : MainAxisAlignment.spaceBetween,
         children: [
           if (turkishImask != null)
             Flexible(
@@ -118,9 +133,9 @@ class ResponsiveMiniSalahBarWidget extends StatelessOrientationWidget {
     }
 
     return Padding(
-      padding: EdgeInsets.symmetric(horizontal: 1.vw),
+      padding: EdgeInsets.symmetric(horizontal: horizontalPadding ?? (useCompactLayout ? 0.5.vw : 1.vw)),
       child: Wrap(
-        spacing: 2.vw,
+        spacing: itemSpacing ?? (useCompactLayout ? 1.vw : 2.vw),
         runSpacing: 2.vh,
         crossAxisAlignment: WrapCrossAlignment.center,
         alignment: WrapAlignment.center,


### PR DESCRIPTION
## 📝 Summary

**This PR fixes** #1861

## Description

This PR addresses the UI spacing issues in the iqama countdown screen where there was excessive empty space at the top and too much horizontal spacing between prayer times.

### Changes Made:
- ✅ Reduced the top margin of the time/date widget from 25vh to 20vh to move content upward
- ✅ Made ResponsiveMiniSalahBarWidget and ResponsiveMiniSalahBarTurkishWidget customizable with spacing parameters
- ✅ Added `useCompactLayout` flag to enable tighter spacing for specific screens
- ✅ Applied compact layout to iqama countdown screen for better visual balance
- ✅ Maintained all font sizes unchanged as per requirement

### Benefits:
- Eliminates code duplication by reusing existing widgets with customization
- Maintains backward compatibility for other screens
- Creates a more balanced and compact layout for the iqama countdown screen
- Follows DRY principle with a cleaner architecture

## Tests

### 🧪 Use case 1

**💬 Description:** Iqama countdown screen layout optimization

The iqama countdown screen now has:
- Less empty space at the top
- More compact horizontal spacing between prayer times  
- Better visual balance with the countdown timer more centered
- All font sizes remain the same

## 📷 Screenshots

After: Reduced top margin and compact prayer time spacing

<img width="970" height="554" alt="image" src="https://github.com/user-attachments/assets/99c80fd6-d66b-46ac-b777-0b0733375f00" />

Before: Large empty space above the time widget and wide gaps between prayer times

<img width="966" height="549" alt="image" src="https://github.com/user-attachments/assets/bc3e4d04-32d3-46b3-a79f-1f0fca0041ec" />

## Checklist:

- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).