### PR TITLE
fix: improve layout responsiveness in MosqueInformationWidget

### DIFF
--- a/lib/src/pages/home/widgets/MosqueInformationWidget.dart
+++ b/lib/src/pages/home/widgets/MosqueInformationWidget.dart
@@ -29,75 +29,75 @@ class MosqueInformationWidget extends StatelessWidget {
         child: Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-          Text(
-            association,
-            style: TextStyle(
-              color: Colors.white,
-              fontSize: 10.sp,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-          if (mosque!.phone != null) ...[
-            SizedBox(width: 2.w),
-            Icon(
-              Icons.phone_iphone,
-              color: Colors.white,
-              size: 12.sp,
-            ),
-            SizedBox(width: 1.w),
-            FittedBox(
-              fit: BoxFit.scaleDown,
-              child: Text(
-                phoneNumber,
-                style: TextStyle(
-                  color: Colors.white,
-                  fontSize: 10.sp,
-                  fontWeight: FontWeight.w600,
-                ),
+            Text(
+              association,
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 10.sp,
+                fontWeight: FontWeight.w600,
               ),
             ),
-          ],
-          if (mosque.site != null && mosque.site!.isNotEmpty) ...[
-            SizedBox(width: 2.w),
-            Icon(
-              Icons.language,
-              color: Colors.white,
-              size: 12.sp,
-            ),
-            SizedBox(width: 1.w),
-            FittedBox(
-              fit: BoxFit.scaleDown,
-              child: Text(
-                website,
-                style: TextStyle(
-                  color: Colors.white,
-                  fontSize: 10.sp,
-                  fontWeight: FontWeight.w600,
+            if (mosque!.phone != null) ...[
+              SizedBox(width: 2.w),
+              Icon(
+                Icons.phone_iphone,
+                color: Colors.white,
+                size: 12.sp,
+              ),
+              SizedBox(width: 1.w),
+              FittedBox(
+                fit: BoxFit.scaleDown,
+                child: Text(
+                  phoneNumber,
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 10.sp,
+                    fontWeight: FontWeight.w600,
+                  ),
                 ),
               ),
-            ),
-          ],
-          if (mosque.email != null && mosque.email!.isNotEmpty) ...[
-            SizedBox(width: 2.w),
-            Icon(
-              Icons.email,
-              color: Colors.white,
-              size: 12.sp,
-            ),
-            SizedBox(width: 1.w),
-            FittedBox(
-              fit: BoxFit.scaleDown,
-              child: Text(
-                email,
-                style: TextStyle(
-                  color: Colors.white,
-                  fontSize: 10.sp,
-                  fontWeight: FontWeight.w600,
+            ],
+            if (mosque.site != null && mosque.site!.isNotEmpty) ...[
+              SizedBox(width: 2.w),
+              Icon(
+                Icons.language,
+                color: Colors.white,
+                size: 12.sp,
+              ),
+              SizedBox(width: 1.w),
+              FittedBox(
+                fit: BoxFit.scaleDown,
+                child: Text(
+                  website,
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 10.sp,
+                    fontWeight: FontWeight.w600,
+                  ),
                 ),
               ),
-            ),
+            ],
+            if (mosque.email != null && mosque.email!.isNotEmpty) ...[
+              SizedBox(width: 2.w),
+              Icon(
+                Icons.email,
+                color: Colors.white,
+                size: 12.sp,
+              ),
+              SizedBox(width: 1.w),
+              FittedBox(
+                fit: BoxFit.scaleDown,
+                child: Text(
+                  email,
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 10.sp,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ],
           ],
-        ],
         ),
       ),
     );

--- a/lib/src/pages/home/widgets/MosqueInformationWidget.dart
+++ b/lib/src/pages/home/widgets/MosqueInformationWidget.dart
@@ -24,9 +24,11 @@ class MosqueInformationWidget extends StatelessWidget {
 
     return Padding(
       padding: EdgeInsets.symmetric(vertical: 2.5.vh, horizontal: 2.w),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
+      child: FittedBox(
+        fit: BoxFit.scaleDown,
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
           Text(
             association,
             style: TextStyle(
@@ -43,12 +45,15 @@ class MosqueInformationWidget extends StatelessWidget {
               size: 12.sp,
             ),
             SizedBox(width: 1.w),
-            Text(
-              phoneNumber,
-              style: TextStyle(
-                color: Colors.white,
-                fontSize: 10.sp,
-                fontWeight: FontWeight.w600,
+            FittedBox(
+              fit: BoxFit.scaleDown,
+              child: Text(
+                phoneNumber,
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 10.sp,
+                  fontWeight: FontWeight.w600,
+                ),
               ),
             ),
           ],
@@ -60,12 +65,15 @@ class MosqueInformationWidget extends StatelessWidget {
               size: 12.sp,
             ),
             SizedBox(width: 1.w),
-            Text(
-              website,
-              style: TextStyle(
-                color: Colors.white,
-                fontSize: 10.sp,
-                fontWeight: FontWeight.w600,
+            FittedBox(
+              fit: BoxFit.scaleDown,
+              child: Text(
+                website,
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 10.sp,
+                  fontWeight: FontWeight.w600,
+                ),
               ),
             ),
           ],
@@ -77,16 +85,20 @@ class MosqueInformationWidget extends StatelessWidget {
               size: 12.sp,
             ),
             SizedBox(width: 1.w),
-            Text(
-              email,
-              style: TextStyle(
-                color: Colors.white,
-                fontSize: 10.sp,
-                fontWeight: FontWeight.w600,
+            FittedBox(
+              fit: BoxFit.scaleDown,
+              child: Text(
+                email,
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 10.sp,
+                  fontWeight: FontWeight.w600,
+                ),
               ),
             ),
           ],
         ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
📝 **Summary**
---
issues closed #1225

**This PR fixes** RenderFlex overflow in MosqueInformationWidget

**Description**
---
Fixed a RenderFlex overflow error where the mosque information row was overflowing by 40 pixels on the right side. The issue occurred when displaying multiple pieces of mosque information (association name, phone number, website, and email) in a horizontal Row widget.

**Solution:**
- Wrapped the Row widget in a FittedBox with BoxFit.scaleDown
- This ensures the entire content scales down proportionally when it would exceed the available width
- Maintains the horizontal layout while preventing overflow errors

**Tests**
---
🧪 **Use case 1**
---
💬 **Description:**
Test with mosque data containing long association name, phone number, website, and email to ensure no overflow occurs

📷 **Screenshots or GIFs (if applicable):**
Before: RenderFlex overflow error with 40 pixels overflow
After: Content scales down to fit available space without overflow


**Checklist:**
---
- [x] **Coding Standards:** I have reviewed my code to ensure it follows the project's coding standards.
- [x] **Testing:** I have tested the changes and they work as expected.
- [x] **Merge Conflicts:** I have resolved any merge conflicts with the latest main/development branch.
- [x] **Branch Status:** The branch is up-to-date with the target branch (main/development).